### PR TITLE
feat(workflow): wire Grug TPM bot - DoR gate + weekly pulse

### DIFF
--- a/.github/workflows/grug.pr-gate.yml
+++ b/.github/workflows/grug.pr-gate.yml
@@ -1,0 +1,23 @@
+name: Grug · PR DoR check
+
+# Calls the reusable Grug workflow at githumps/grug (public). Static
+# checks are advisory by default for fresh rollout (strict: false). Flip
+# to strict: true once the repo's PR template aligns with DoR.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  grug:
+    name: Grug · DoR check
+    uses: githumps/grug/.github/workflows/_reusable.grug-pr-gate.yml@main
+    with:
+      strict: false
+    secrets:
+      poolside_api_key: ${{ secrets.POOLSIDE_API_KEY }}

--- a/.github/workflows/grug.pulse.yml
+++ b/.github/workflows/grug.pulse.yml
@@ -1,0 +1,24 @@
+name: Grug · weekly pulse
+
+# Mondays 13:00 UTC — opens an issue summarizing iteration health.
+# Filterable later via label `grug-pulse`.
+
+on:
+  schedule:
+    - cron: '0 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  pulse:
+    name: Grug · pulse
+    uses: githumps/grug/.github/workflows/_reusable.grug-pulse.yml@main
+    with:
+      issue_label: "grug-pulse"
+      mode: "weekly"
+    secrets:
+      poolside_api_key: ${{ secrets.POOLSIDE_API_KEY }}


### PR DESCRIPTION
## Why

Wire up Grug TPM bot caller workflows so PRs get Definition-of-Ready feedback + weekly iteration pulse. Grug source-of-truth at githumps/grug (public). Advisory mode (strict: false) for first rollout, flip to strict: true once PR template aligns.

## Adds
- `.github/workflows/grug.pr-gate.yml` — every PR open/edit/sync
- `.github/workflows/grug.pulse.yml` — Mon 13:00Z weekly groom signal

## Acceptance criteria
- [x] `grug-bot` GitHub Environment created (out-of-band)
- [x] `POOLSIDE_API_KEY` env-scoped secret set (out-of-band)
- [ ] PR-gate fires on this PR (advisory only, sticky DoR comment posted)
- [ ] After merge: weekly pulse fires Mon or via workflow_dispatch + issue opens

## Out of scope
- Per-repo PR-template alignment with DoR — separate cleanup PR
- Strict mode flip — separate PR after PR-template lands

**Size:** XS

Refs: githumps/grug#1
