### PR TITLE
ci: adopt shared infra-public Pages reusable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,7 @@
 name: Deploy to GitHub Pages
 
+# Thin caller of the shared infra-public Pages reusable (SHA-pinned).
+
 on:
   push:
     branches:
@@ -13,28 +15,8 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: '.'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+    uses: githumps/infra-public/.github/workflows/_reusable.pages-deploy.yml@ad1bcef8ff3ff468e0cadab07053a066993e8031
+    with:
+      artifact_path: "."


### PR DESCRIPTION
## Why

Replaces this repo's inline GitHub Pages publish (`configure-pages` → `upload-pages-artifact` → `deploy-pages`) with the shared SHA-pinned reusable `githumps/infra-public/.github/workflows/_reusable.pages-deploy.yml`, so the Pages pattern lives in one canonical place instead of drifting per-repo.

## What

The deploy workflow becomes a thin caller of the reusable (`artifact_path: "."`). Triggers + Pages permissions preserved.

## Acceptance criteria

- [x] Workflow calls the SHA-pinned infra-public pages-deploy reusable
- [x] Push/dispatch triggers preserved
- [x] Pages permissions (`contents:read`, `pages:write`, `id-token:write`) granted by the caller
- [ ] Post-merge: the Pages deploy runs green via the reusable (verify on next push)

## Out of scope

- The reusable itself (already merged in infra-public).

Size: XS

Part of githumps/infrastructure#994
