### PR TITLE
chore: repoint infra-public reusables to verb-first names

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   deploy:
-    uses: githumps/infra-public/.github/workflows/_reusable.pages-deploy.yml@ad1bcef8ff3ff468e0cadab07053a066993e8031
+    uses: githumps/infra-public/.github/workflows/deploy.pages.yml@cd83e5727c0a7b904f780960664a51b3a3a0c685
     with:
       artifact_path: "."


### PR DESCRIPTION
## Why

The infra-public reusable workflows were renamed to a consistent verb-first `<verb>.<scope>` scheme (build./check./verify./deploy./ship.) so the step-vs-pipeline tier is obvious. This repoints this repo's pins to the new names + the post-rename SHA. No behavior change — the reusables are byte-identical, only renamed.

## Acceptance criteria

- [ ] Every `_reusable.*` ref points to its new verb-first name
- [ ] Pinned to the post-rename infra-public SHA (cd83e57)
- [ ] No remaining `_reusable.` references

Size: S

## Out of scope

- Behavior/interface changes to the reusables (none).