### PR TITLE
ci: add issue-close completeness guard (#947)

### DIFF
--- a/.github/workflows/guard.issue-close-completeness.yml
+++ b/.github/workflows/guard.issue-close-completeness.yml
@@ -1,0 +1,16 @@
+name: Guard · issue-close completeness
+
+# Thin caller of the shared reusable in githumps/infra-public — reopens an issue
+# closed as completed while it still has unchecked acceptance/test boxes. Logic +
+# escape hatches live in the reusable.
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  guard:
+    uses: githumps/infra-public/.github/workflows/check.issue-close-completeness.yml@cd83e5727c0a7b904f780960664a51b3a3a0c685


### PR DESCRIPTION
## Why

Roll out the org-wide issue-close completeness guard (githumps/infrastructure#947). It reopens an issue closed as "completed" while its body still has unchecked acceptance/test checkboxes — so work isn't marked done prematurely. Logic + escape hatches live in the shared `githumps/infra-public` reusable; this is just a thin caller.

## Acceptance criteria

- [ ] `.github/workflows/guard.issue-close-completeness.yml` calls the shared `githumps/infra-public` reusable
- [ ] Closing an issue with unchecked `- [ ]` boxes reopens it with a guard comment
- [ ] A `force-close` label or exempt sections (Out of scope / Blocked by) bypass it (handled by the reusable)

Size: XS

## Out of scope

- Enforcing on PRs (issues-only).
- Changing the guard logic (lives in the reusable).

Part of githumps/infrastructure#947
