### PR TITLE
feat: M1 core-systems rewrite + temper SDD + visual modernization

### DIFF
--- a/.github/workflows/check.temper-specs.yml
+++ b/.github/workflows/check.temper-specs.yml
@@ -1,0 +1,109 @@
+name: Check · temper · spec verification cascade
+
+# Runs the temper kernel's L0 (Z3 SMT) + L1 (model check) + L2
+# (simulation) + L3 (proptest) cascade against each spec under
+# `specs/`. Fails the PR if any spec stops being kernel-acceptable.
+#
+# Temper is a research tool; there is no published binary, so this
+# workflow builds the CLI from source at a pinned SHA. Self-hosted
+# runners can bake the binary at /opt/temper/<sha>/temper for the
+# fast path; ubuntu-latest cold-builds with cargo (~3-4 min).
+#
+# Pinning policy: bump TEMPER_REPO_SHA below in lockstep with
+# install-temper.sh in the skill repo. The cascade may surface new
+# lints or stricter parses after a bump.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'specs/**'
+      - '.github/workflows/check.temper-specs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-temper-specs-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TEMPER_REPO: nerdsane/temper
+  TEMPER_REPO_SHA: 3c2e6267ec179f94ef67da00e373eccf577f23ca
+
+jobs:
+  verify:
+    name: temper verify
+    runs-on: ubuntu-latest
+    # Swap to self-hosted runner for faster builds if you have one:
+    # runs-on: [self-hosted, <your-runner-label>]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Locate or build temper binary
+        id: temper-locate
+        # Fast path: pre-built binary at /opt/temper/<sha>/temper
+        # (only present on self-hosted runners that baked it).
+        # Cold path: cargo build from source.
+        run: |
+          BAKED=/opt/temper/${{ env.TEMPER_REPO_SHA }}/temper
+          if [[ -x $BAKED ]]; then
+            echo "Using pre-built temper at $BAKED"
+            echo "binary=$BAKED" >> "$GITHUB_OUTPUT"
+            echo "needs_build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No pre-built temper found; will build from source"
+            echo "binary=/tmp/temper/target/release/temper" >> "$GITHUB_OUTPUT"
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Rust toolchain
+        if: steps.temper-locate.outputs.needs_build == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install temper build deps (cold-path only)
+        if: steps.temper-locate.outputs.needs_build == 'true'
+        run: |
+          missing=()
+          pkg-config --exists openssl || missing+=("libssl-dev" "pkg-config")
+          dpkg -s libz3-dev >/dev/null 2>&1 || missing+=("libz3-dev")
+          dpkg -s libclang-dev >/dev/null 2>&1 || missing+=("libclang-dev")
+          if (( ${#missing[@]} > 0 )); then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq "${missing[@]}"
+          fi
+
+      - name: Clone + build temper (cold-path only)
+        if: steps.temper-locate.outputs.needs_build == 'true'
+        run: |
+          rm -rf /tmp/temper
+          git clone https://github.com/${{ env.TEMPER_REPO }}.git /tmp/temper
+          cd /tmp/temper
+          git checkout ${{ env.TEMPER_REPO_SHA }}
+          cargo build --release --bin temper
+
+      # Per-spec verify steps land below this line. The add-spec-to-workflow.sh
+      # script appends one step per spec dir. Manual edits welcome — just keep
+      # the format consistent so future appends slot in cleanly.
+
+      - name: Verify spec 0001 (Battle)
+        run: ${{ steps.temper-locate.outputs.binary }} verify -s specs/0001-battle/
+
+      - name: Verify spec 0002 (Capture)
+        run: ${{ steps.temper-locate.outputs.binary }} verify -s specs/0002-capture/
+
+      - name: Verify spec 0003 (Party)
+        run: ${{ steps.temper-locate.outputs.binary }} verify -s specs/0003-party/
+
+      - name: Verify spec 0004 (Progression)
+        run: ${{ steps.temper-locate.outputs.binary }} verify -s specs/0004-progression/
+
+      - name: Verify spec 0005 (SaveLoad)
+        run: ${{ steps.temper-locate.outputs.binary }} verify -s specs/0005-save-load/
+
+      - name: Verify spec 0006 (MapWarp)
+        run: ${{ steps.temper-locate.outputs.binary }} verify -s specs/0006-map-warp/
+
+      - name: Verify spec 0007 (Economy)
+        run: ${{ steps.temper-locate.outputs.binary }} verify -s specs/0007-economy/

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
@@ -8,6 +9,7 @@
     <title>Train Battle RPG - A Pokemon-Style Train Adventure!</title>
     <link rel="stylesheet" href="styles.css">
 </head>
+
 <body>
     <div id="game-container">
         <div id="game-header">
@@ -92,7 +94,8 @@
             <p>Collect all 151 train species and become the ultimate Train Master!</p>
             <p><strong>Auto-saves every 30 seconds!</strong> Use Save/Load buttons above for manual control.</p>
             <p style="margin-top: 15px;">
-                <a href="traindex.html" style="display: inline-block; padding: 10px 20px; background: #ffd700; color: #000; text-decoration: none; border-radius: 10px; font-weight: bold; border: 2px solid #000;">
+                <a href="traindex.html"
+                    style="display: inline-block; padding: 10px 20px; background: #ffd700; color: #000; text-decoration: none; border-radius: 10px; font-weight: bold; border: 2px solid #000;">
                     🚂 View Traindex - All 151 Trains
                 </a>
             </p>
@@ -103,6 +106,7 @@
     <script src="js/constants.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/train-data.js"></script>
+    <script src="js/items.js"></script>
     <script src="js/moves.js"></script>
     <script src="js/train.js"></script>
     <script src="js/battle.js"></script>
@@ -115,8 +119,10 @@
     <!-- coal_harbor_gym.js removed - gym now in world-maps.js -->
     <script src="js/input.js"></script>
     <script src="js/graphics.js"></script>
-    <script src="js/game.js"></script>
-    <script src="js/mobile-controls.js"></script>
-    <script src="js/main.js"></script>
+    <script src="js/audio.js"></script>
+    <script src="js/game.js?v=6"></script>
+    <script src="js/mobile-controls.js?v=6"></script>
+    <script src="js/main.js?v=6"></script>
 </body>
+
 </html>

--- a/js/audio.js
+++ b/js/audio.js
@@ -1,0 +1,44 @@
+/**
+ * Audio Manager - Placeholder for sound effects and music
+ */
+
+class AudioManager {
+    constructor() {
+        this.sounds = {};
+        this.music = {};
+        this.currentMusic = null;
+        this.muted = false;
+    }
+
+    load() {
+        // Placeholder for loading audio files
+        console.log('🔊 Audio Manager initialized (No audio files found)');
+    }
+
+    playSound(name) {
+        if (this.muted) return;
+        // console.log(`🔊 Playing sound: ${name}`);
+    }
+
+    playMusic(name) {
+        if (this.muted) return;
+        if (this.currentMusic === name) return;
+
+        // console.log(`🎵 Playing music: ${name}`);
+        this.currentMusic = name;
+    }
+
+    stopMusic() {
+        this.currentMusic = null;
+    }
+
+    toggleMute() {
+        this.muted = !this.muted;
+        return this.muted;
+    }
+}
+
+// Export
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = AudioManager;
+}

--- a/js/battle.js
+++ b/js/battle.js
@@ -3,22 +3,30 @@
  */
 
 class Battle {
-    constructor(playerTrains, enemyTrains, isWild = true, trainerNPC = null) {
+    constructor(game, playerTrains, enemyTrains, isWild = true, trainerNPC = null) {
+        this.game = game;
         this.playerTrains = playerTrains;
         this.enemyTrains = enemyTrains;
         this.isWild = isWild;
         this.trainerNPC = trainerNPC;
 
-        // If trainerNPC is actually playerInventory (backwards compatibility)
-        if (trainerNPC && !trainerNPC.name && typeof trainerNPC === 'object') {
-            this.playerInventory = trainerNPC;
-            this.trainerNPC = null;
-        } else {
-            this.playerInventory = null;
-        }
+        // Inventory is read live from the player (single source of truth) rather
+        // than passed in via an ambiguous overloaded parameter.
+        this.playerInventory = (game && game.player) ? game.player.items : null;
 
         this.playerActive = playerTrains[0];
         this.enemyActive = enemyTrains[0];
+
+        // Gen-1 stat stages live on the battle, per side, not on the Train
+        // instance (so they reset when the battle ends and never persist).
+        this.stages = {
+            player: { attack: 0, defense: 0, speed: 0, special: 0 },
+            enemy: { attack: 0, defense: 0, speed: 0, special: 0 }
+        };
+        // Per-turn flinch flags (cleared at the start of each turn).
+        this.flinch = { player: false, enemy: false };
+        // Ordered actions for the current turn.
+        this.turnActions = [];
 
         this.state = CONSTANTS.BATTLE_STATES.INTRO;
         this.messages = [];
@@ -156,7 +164,7 @@ class Battle {
                     break;
                 case 1:
                     // ITEM
-                    if (this.playerInventory) {
+                    if (this.getUsableItems().length > 0) {
                         this.state = CONSTANTS.BATTLE_STATES.ITEM;
                         this.itemSelection = 0;
                     } else {
@@ -166,10 +174,8 @@ class Battle {
                     }
                     break;
                 case 2:
-                    // POKEMON - not implemented
-                    this.addMessage("No other trains available!");
-                    this.state = CONSTANTS.BATTLE_STATES.MESSAGE;
-                    this.currentMessage = 0;
+                    // TRAIN - switch to a healthy benched train (costs the turn).
+                    this.switchToBenchedTrain();
                     break;
                 case 3:
                     // RUN
@@ -199,134 +205,275 @@ class Battle {
         } else if (action === 'right' && this.moveSelection % 2 === 0 && this.moveSelection + 1 < moves.length) {
             this.moveSelection++;
         } else if (action === 'a') {
-            this.executePlayerMove(moves[this.moveSelection]);
+            this.executeTurn(moves[this.moveSelection]);
         } else if (action === 'b') {
             this.state = CONSTANTS.BATTLE_STATES.MENU;
         }
     }
 
-    executePlayerMove(moveName) {
+    // Entry point when the player commits to a move. Builds the ordered turn
+    // and resolves it action-by-action. Damage is computed at resolution time
+    // (not here), so the second attacker hits the post-first-hit state.
+    executeTurn(playerMoveName) {
         this.state = CONSTANTS.BATTLE_STATES.ANIMATION;
+        this.flinch.player = false;
+        this.flinch.enemy = false;
 
-        // Player attacks first (simplified, should check speed)
-        this.addMessage(`${this.playerActive.species.name} used ${moveName}!`);
-
-        const result = calculateDamage(this.playerActive, this.enemyActive, moveName);
-
-        // Trigger attack animation
-        const moveData = MOVES_DB[moveName];
-        if (moveData?.category === 'physical') {
-            this.playerShake = 3; // Physical: attacker shakes forward
-        }
-
-        this.animationQueue.push({
-            callback: () => {
-                if (!result.hit) {
-                    this.addMessage("Attack missed!");
-                } else {
-                    // Show damage flash on defender
-                    this.enemyFlash = 1;
-
-                    if (result.critical) {
-                        this.addMessage("Critical hit!");
-                    }
-
-                    const effectivenessText = getEffectivenessText(result.effectiveness);
-                    if (effectivenessText) {
-                        this.addMessage(effectivenessText);
-                    }
-
-                    this.enemyActive.takeDamage(result.damage);
-
-                    if (this.enemyActive.fainted) {
-                        this.addMessage(`Enemy ${this.enemyActive.species.name} fainted!`);
-                        this.handleVictory();
-                        return;
-                    }
-                }
-
-                // Enemy turn
-                this.executeEnemyMove();
-            }
-        });
+        const enemyMoveName = Utils.randomChoice(this.enemyActive.moves) || 'Ram';
+        this.turnActions = this.orderActions(playerMoveName, enemyMoveName);
+        this.processNextAction();
     }
 
-    executeEnemyMove() {
-        // Simple AI: pick random move
-        const moves = this.enemyActive.moves;
-        const moveName = Utils.randomChoice(moves);
+    // Order by move priority, then effective (status-adjusted) speed, ties random.
+    orderActions(playerMoveName, enemyMoveName) {
+        const playerAction = { side: 'player', attacker: this.playerActive, defender: this.enemyActive, move: playerMoveName };
+        const enemyAction = { side: 'enemy', attacker: this.enemyActive, defender: this.playerActive, move: enemyMoveName };
 
-        this.addMessage(`Enemy ${this.enemyActive.species.name} used ${moveName}!`);
+        const pPrio = (MOVES_DB[playerMoveName] && MOVES_DB[playerMoveName].effect && MOVES_DB[playerMoveName].effect.priority) || 0;
+        const ePrio = (MOVES_DB[enemyMoveName] && MOVES_DB[enemyMoveName].effect && MOVES_DB[enemyMoveName].effect.priority) || 0;
+        if (pPrio !== ePrio) return pPrio > ePrio ? [playerAction, enemyAction] : [enemyAction, playerAction];
 
-        const result = calculateDamage(this.enemyActive, this.playerActive, moveName);
+        const pSpeed = this.effectiveSpeed('player', this.playerActive);
+        const eSpeed = this.effectiveSpeed('enemy', this.enemyActive);
+        if (pSpeed !== eSpeed) return pSpeed > eSpeed ? [playerAction, enemyAction] : [enemyAction, playerAction];
 
-        // Trigger attack animation
-        const moveData = MOVES_DB[moveName];
-        if (moveData?.category === 'physical') {
-            this.enemyShake = 3; // Physical: attacker shakes forward
+        return Utils.randomInt(0, 1) === 0 ? [playerAction, enemyAction] : [enemyAction, playerAction];
+    }
+
+    effectiveSpeed(side, train) {
+        let speed = this.effectiveStat(side, train, 'speed');
+        if (train.status === 'paralyze') speed = Math.floor(speed / 4); // Gen-1 paralysis
+        return speed;
+    }
+
+    // Gen-1 stat-stage multiplier.
+    stageMult(stage) {
+        return stage >= 0 ? (2 + stage) / 2 : 2 / (2 - stage);
+    }
+
+    effectiveStat(side, train, statName) {
+        const stage = (this.stages[side] && this.stages[side][statName]) || 0;
+        return Math.max(1, Math.floor(train[statName] * this.stageMult(stage)));
+    }
+
+    resetStages(side) {
+        this.stages[side] = { attack: 0, defense: 0, speed: 0, special: 0 };
+    }
+
+    // Pull the next action off the turn queue and resolve it.
+    processNextAction() {
+        // Stop the turn if either active train has fainted; checkBattleEnd
+        // (the single end-of-battle owner) runs once the queue drains.
+        if (this.playerActive.fainted || this.enemyActive.fainted) {
+            this.turnActions = [];
+            return;
+        }
+        if (this.turnActions.length === 0) {
+            this.endOfTurn();
+            return;
         }
 
-        this.animationQueue.push({
-            callback: () => {
-                if (!result.hit) {
-                    this.addMessage("Attack missed!");
-                } else {
-                    // Show damage flash on defender
-                    this.playerFlash = 1;
+        const action = this.turnActions.shift();
+        if (action.attacker.fainted) {
+            this.processNextAction();
+            return;
+        }
 
-                    if (result.critical) {
-                        this.addMessage("Critical hit!");
-                    }
+        const prefix = action.side === 'enemy' ? 'Enemy ' : '';
 
-                    const effectivenessText = getEffectivenessText(result.effectiveness);
-                    if (effectivenessText) {
-                        this.addMessage(effectivenessText);
-                    }
+        // Paralysis full-skip (25%).
+        if (action.attacker.status === 'paralyze' && Utils.randomInt(1, 100) <= 25) {
+            this.addMessage(`${prefix}${action.attacker.species.name} is paralyzed! It can't move!`);
+            this.animationQueue.push({ callback: () => this.processNextAction() });
+            return;
+        }
+        // Flinch (set by a faster attacker earlier this turn).
+        if (this.flinch[action.side]) {
+            this.flinch[action.side] = false;
+            this.addMessage(`${prefix}${action.attacker.species.name} flinched and couldn't move!`);
+            this.animationQueue.push({ callback: () => this.processNextAction() });
+            return;
+        }
 
-                    this.playerActive.takeDamage(result.damage);
+        this.addMessage(`${prefix}${action.attacker.species.name} used ${action.move}!`);
+        this.animationQueue.push({ callback: () => this.performAttack(action) });
+    }
 
-                    if (this.playerActive.fainted) {
-                        this.addMessage(`${this.playerActive.species.name} fainted!`);
-                        this.handleDefeat();
-                        return;
-                    }
-                }
+    // Resolve a single attack. Damage is computed HERE, against current state.
+    performAttack(action) {
+        const { side, attacker, defender, move } = action;
+        const moveData = MOVES_DB[move];
+        const defenderSide = side === 'player' ? 'enemy' : 'player';
+        const physical = moveData.category === 'physical';
 
-                // Back to menu
-                this.state = CONSTANTS.BATTLE_STATES.MESSAGE;
-                this.currentMessage = 0;
+        if (physical) {
+            if (side === 'player') this.playerShake = 3; else this.enemyShake = 3;
+        }
+
+        // Status moves: apply effect, no damage.
+        if (moveData.category === 'status') {
+            this.applyMoveEffect(action, moveData);
+            this.processNextAction();
+            return;
+        }
+
+        // Staged + burn-adjusted attacking stat.
+        let attackStat = this.effectiveStat(side, attacker, physical ? 'attack' : 'special');
+        if (physical && attacker.status === 'burn') attackStat = Math.floor(attackStat / 2);
+        const defenseStat = this.effectiveStat(defenderSide, defender, physical ? 'defense' : 'special');
+
+        const hits = (moveData.effect && moveData.effect.multi_hit) ? Utils.randomInt(2, 5) : 1;
+        let totalDamage = 0;
+        let result = { hit: true, critical: false, effectiveness: 1.0 };
+        for (let h = 0; h < hits; h++) {
+            result = calculateDamage(attacker, defender, move, { attackStat, defenseStat });
+            if (!result.hit) break;
+            if (side === 'player') this.enemyFlash = 1; else this.playerFlash = 1;
+            defender.takeDamage(result.damage);
+            totalDamage += result.damage;
+            if (defender.fainted) break;
+        }
+
+        if (!result.hit && totalDamage === 0) {
+            this.addMessage('Attack missed!');
+            this.processNextAction();
+            return;
+        }
+
+        if (result.critical) this.addMessage('Critical hit!');
+        const effText = getEffectivenessText(result.effectiveness);
+        if (effText) this.addMessage(effText);
+        if (hits > 1) this.addMessage(`Hit ${hits} times!`);
+
+        // Recoil to the attacker.
+        if (moveData.effect && moveData.effect.recoil && totalDamage > 0) {
+            const recoil = Math.max(1, Math.floor(totalDamage * moveData.effect.recoil / 100));
+            attacker.takeDamage(recoil);
+            this.addMessage(`${attacker.species.name} is hit with recoil!`);
+        }
+
+        if (defender.fainted) {
+            this.addMessage(`${defenderSide === 'enemy' ? 'Enemy ' : ''}${defender.species.name} fainted!`);
+            this.processNextAction();
+            return;
+        }
+
+        // Secondary effects only land if the defender survived.
+        this.applyMoveEffect(action, moveData);
+        this.processNextAction();
+    }
+
+    // Apply a move's secondary effect (status / stat stages / flinch).
+    applyMoveEffect(action, moveData) {
+        const effect = moveData.effect;
+        if (!effect) return;
+        const { side, defender } = action;
+        const defenderSide = side === 'player' ? 'enemy' : 'player';
+        const roll = (chance) => Utils.randomInt(1, 100) <= chance;
+
+        // One status condition at a time.
+        if (!defender.status) {
+            if (effect.paralyze === 100 || (effect.paralyze_chance && roll(effect.paralyze_chance))) {
+                defender.status = 'paralyze';
+                this.addMessage(`${defender.species.name} is paralyzed!`);
+            } else if (effect.burn_chance && roll(effect.burn_chance)) {
+                defender.status = 'burn';
+                this.addMessage(`${defender.species.name} was burned!`);
+            } else if (effect.poison_chance && roll(effect.poison_chance)) {
+                defender.status = 'poison';
+                this.addMessage(`${defender.species.name} was poisoned!`);
             }
-        });
+        }
+
+        if (effect.flinch_chance && roll(effect.flinch_chance)) {
+            this.flinch[defenderSide] = true;
+        }
+
+        const bump = (targetSide, stat, delta, label) => {
+            const stages = this.stages[targetSide];
+            const before = stages[stat];
+            stages[stat] = Math.max(-6, Math.min(6, before + delta));
+            if (stages[stat] !== before) {
+                const who = targetSide === 'player' ? this.playerActive : this.enemyActive;
+                this.addMessage(`${who.species.name}'s ${label} ${delta > 0 ? 'rose' : 'fell'}!`);
+            }
+        };
+        if (effect.raise_defense) bump(side, 'defense', effect.raise_defense, 'Defense');
+        if (effect.lower_defense) bump(defenderSide, 'defense', -effect.lower_defense, 'Defense');
+        if (effect.raise_attack) bump(side, 'attack', effect.raise_attack, 'Attack');
+        if (effect.lower_attack) bump(defenderSide, 'attack', -effect.lower_attack, 'Attack');
+        if (effect.lower_speed) bump(defenderSide, 'speed', -effect.lower_speed, 'Speed');
+        if (effect.raise_special && effect.raise_special <= 6) bump(side, 'special', effect.raise_special, 'Special');
+        if (effect.lower_special) bump(defenderSide, 'special', -effect.lower_special, 'Special');
+    }
+
+    // Residual damage (burn/poison) at end of turn, then back to the menu.
+    endOfTurn() {
+        const residual = (train, side) => {
+            if (train.fainted || !train.status) return;
+            let dmg = 0;
+            if (train.status === 'burn') dmg = Math.max(1, Math.floor(train.maxHP / 16));
+            else if (train.status === 'poison') dmg = Math.max(1, Math.floor(train.maxHP / 8));
+            if (dmg > 0) {
+                const prefix = side === 'enemy' ? 'Enemy ' : '';
+                train.takeDamage(dmg);
+                this.addMessage(`${prefix}${train.species.name} is hurt by its ${train.status}!`);
+                if (train.fainted) this.addMessage(`${prefix}${train.species.name} fainted!`);
+            }
+        };
+        residual(this.playerActive, 'player');
+        residual(this.enemyActive, 'enemy');
+
+        if (!this.playerActive.fainted && !this.enemyActive.fainted) {
+            this.state = CONSTANTS.BATTLE_STATES.MESSAGE;
+            this.currentMessage = 0;
+        }
+    }
+
+    // Used after a potion/boxcar - the wild/enemy train gets one free attack.
+    enemyFreeTurn() {
+        this.flinch.player = false;
+        this.flinch.enemy = false;
+        const move = Utils.randomChoice(this.enemyActive.moves) || 'Ram';
+        this.turnActions = [{ side: 'enemy', attacker: this.enemyActive, defender: this.playerActive, move }];
+        this.processNextAction();
+    }
+
+    // Grant EXP for a defeated enemy to the active train (and evolve if eligible).
+    awardExp(enemyTrain) {
+        const expGained = Math.floor(enemyTrain.species.expYield * enemyTrain.level / 7);
+        this.addMessage(`${this.playerActive.species.name} gained ${expGained} EXP!`);
+        const beforeLevel = this.playerActive.level;
+        this.playerActive.gainExp(expGained);
+        if (this.playerActive.level > beforeLevel) {
+            this.addMessage(`${this.playerActive.species.name} grew to Lv${this.playerActive.level}!`);
+        }
+        // Level-up evolution.
+        if (this.playerActive.canEvolve()) {
+            const oldName = this.playerActive.species.name;
+            if (this.playerActive.evolve()) {
+                this.addMessage(`${oldName} evolved into ${this.playerActive.species.name}!`);
+            }
+        }
     }
 
     handleVictory() {
-        const expGained = Math.floor(this.enemyActive.species.expYield * this.enemyActive.level / 7);
-        this.addMessage(`${this.playerActive.species.name} gained ${expGained} EXP!`);
+        if (this.battleEnded) return;
 
-        this.playerActive.gainExp(expGained);
-
-        // Award money for trainer battles
         if (!this.isWild && this.trainerNPC) {
-            // Calculate money: baseReward × highestTrainLevel × 2
             const highestLevel = Math.max(...this.trainerNPC.party.map(t => t.level));
             const baseReward = this.trainerNPC.baseReward ||
-                              (this.trainerNPC.type === 'gym_leader' ? 100 : 50);
+                (this.trainerNPC.type === 'gym_leader' ? 100 : 50);
             const moneyEarned = baseReward * highestLevel * 2;
-
             this.addMessage(`You won $${moneyEarned}!`);
-
-            // Store money to be awarded by onVictory callback
             this.moneyEarned = moneyEarned;
         } else if (this.isWild) {
-            // Award smaller money for wild battles
-            const moneyEarned = Math.floor(this.enemyActive.level * 10 + Math.random() * 20);
+            const moneyEarned = Math.floor(this.enemyActive.level * 10 + Utils.randomInt(0, 20));
             this.addMessage(`You found $${moneyEarned}!`);
             this.moneyEarned = moneyEarned;
         }
 
-        if (this.onVictory) {
-            this.onVictory();
-        }
+        if (this.onVictory) this.onVictory();
 
         this.state = CONSTANTS.BATTLE_STATES.VICTORY;
         this.battleEnded = true;
@@ -334,6 +481,7 @@ class Battle {
     }
 
     handleDefeat() {
+        if (this.battleEnded) return;
         this.addMessage("You have no more trains!");
         this.addMessage("You blacked out!");
         this.state = CONSTANTS.BATTLE_STATES.DEFEAT;
@@ -341,27 +489,41 @@ class Battle {
         this.playerWon = false;
     }
 
+    // THE single owner of end-of-battle resolution. Called once per drained
+    // animation queue. Idempotent via the battleEnded guard.
     checkBattleEnd() {
+        if (this.battleEnded) return;
+
         if (this.playerActive.fainted) {
-            // Check for more trains
             const nextTrain = this.playerTrains.find(t => !t.fainted);
             if (nextTrain) {
                 this.playerActive = nextTrain;
+                this.resetStages('player');
                 this.addMessage(`Go! ${this.playerActive.species.name}!`);
             } else {
                 this.handleDefeat();
+                return;
             }
         }
 
         if (this.enemyActive.fainted) {
-            // Check for more enemy trains
+            // Award EXP for THIS defeated enemy before sending out the next one.
+            this.awardExp(this.enemyActive);
             const nextTrain = this.enemyTrains.find(t => !t.fainted);
             if (nextTrain) {
                 this.enemyActive = nextTrain;
+                this.resetStages('enemy');
                 this.addMessage(`Enemy sent out ${this.enemyActive.species.name}!`);
             } else {
                 this.handleVictory();
+                return;
             }
+        }
+
+        // Switched in a new train without ending the battle: back to the menu.
+        if (!this.battleEnded) {
+            this.state = CONSTANTS.BATTLE_STATES.MESSAGE;
+            this.currentMessage = 0;
         }
     }
 
@@ -388,35 +550,41 @@ class Battle {
         }
     }
 
+    // Battle item list derived from the live inventory + Items registry.
     getUsableItems() {
-        if (!this.playerInventory) return [];
-
-        const items = [];
-        if (this.playerInventory.potion > 0) {
-            items.push({ name: 'potion', displayName: 'Potion', quantity: this.playerInventory.potion });
-        }
-        if (this.playerInventory.super_potion > 0) {
-            items.push({ name: 'super_potion', displayName: 'Super Potion', quantity: this.playerInventory.super_potion });
-        }
-        if (this.playerInventory.boxcar > 0) {
-            items.push({ name: 'boxcar', displayName: 'Boxcar', quantity: this.playerInventory.boxcar });
-        }
-
-        return items;
+        if (!this.game || !this.game.player) return [];
+        return Items.battleUsable(this.game.player).map(it => ({
+            name: it.id, displayName: it.name, quantity: it.quantity
+        }));
     }
 
     useItem(item) {
-        if (item.name === 'potion' || item.name === 'super_potion') {
-            this.usePotion(item.name);
-        } else if (item.name === 'boxcar') {
-            this.useBoxcar();
+        const def = Items.get(item.name);
+        if (!def) return;
+        if (def.kind === 'capture') this.useBoxcar();
+        else if (def.kind === 'heal') this.usePotion(item.name);
+    }
+
+    // Switch the active train to the next healthy benched one. Costs the turn.
+    switchToBenchedTrain() {
+        const next = this.playerTrains.find(t => t !== this.playerActive && !t.fainted);
+        if (!next) {
+            this.addMessage("No other trains available!");
+            this.state = CONSTANTS.BATTLE_STATES.MESSAGE;
+            this.currentMessage = 0;
+            return;
         }
+        this.state = CONSTANTS.BATTLE_STATES.ANIMATION;
+        this.playerActive = next;
+        this.resetStages('player');
+        this.addMessage(`Go! ${this.playerActive.species.name}!`);
+        this.animationQueue.push({ callback: () => this.enemyFreeTurn() });
     }
 
     usePotion(potionType) {
-        const healAmount = potionType === 'potion' ? 20 : 50;
+        const def = Items.get(potionType);
+        const healAmount = def ? def.amount : 20;
 
-        // Check if train is at full HP
         if (this.playerActive.currentHP === this.playerActive.maxHP) {
             this.addMessage("HP is already full!");
             this.state = CONSTANTS.BATTLE_STATES.MESSAGE;
@@ -424,23 +592,19 @@ class Battle {
             return;
         }
 
-        // Use the potion
         this.state = CONSTANTS.BATTLE_STATES.ANIMATION;
-        const displayName = potionType === 'potion' ? 'Potion' : 'Super Potion';
-        this.addMessage(`You used a ${displayName}!`);
+        this.addMessage(`You used a ${def ? def.name : potionType}!`);
 
         const oldHP = this.playerActive.currentHP;
         this.playerActive.heal(healAmount);
         const actualHealed = this.playerActive.currentHP - oldHP;
 
-        this.playerInventory[potionType]--;
+        this.playerInventory[potionType] = Math.max(0, (this.playerInventory[potionType] || 0) - 1);
 
         this.animationQueue.push({
             callback: () => {
                 this.addMessage(`${this.playerActive.species.name} recovered ${actualHealed} HP!`);
-
-                // Enemy turn
-                this.executeEnemyMove();
+                this.enemyFreeTurn();
             }
         });
     }
@@ -457,7 +621,7 @@ class Battle {
         this.state = CONSTANTS.BATTLE_STATES.ANIMATION;
         this.addMessage("You threw a Boxcar!");
 
-        this.playerInventory.boxcar--;
+        this.playerInventory.boxcar = Math.max(0, (this.playerInventory.boxcar || 0) - 1);
 
         // Gen 1 capture formula
         const catchRate = this.enemyActive.species.catchRate || 45;
@@ -497,237 +661,273 @@ class Battle {
                     ];
                     this.addMessage(shakeMessages[shakes] || "Oh no! The train broke free!");
 
-                    // Enemy turn
-                    this.executeEnemyMove();
+                    // The wild train gets a free turn after a failed catch.
+                    this.enemyFreeTurn();
                 }
             }
         });
     }
 
+    // Rounded-rect path helper.
+    rr(ctx, x, y, w, h, r) {
+        ctx.beginPath();
+        if (ctx.roundRect) { ctx.roundRect(x, y, w, h, r); return; }
+        ctx.moveTo(x + r, y);
+        ctx.arcTo(x + w, y, x + w, y + h, r);
+        ctx.arcTo(x + w, y + h, x, y + h, r);
+        ctx.arcTo(x, y + h, x, y, r);
+        ctx.arcTo(x, y, x + w, y, r);
+        ctx.closePath();
+    }
+
+    hpColor(pct) {
+        const C = CONSTANTS.COLORS;
+        return pct > 0.5 ? C.HP_GREEN : pct > 0.2 ? C.HP_YELLOW : C.HP_RED;
+    }
+
+    // One combatant's status panel: framed card, name + Lv, HP bar, type chips.
+    drawStatusPanel(ctx, train, px, py, pw, showNumbers) {
+        const C = CONSTANTS.COLORS;
+        const ph = 86;
+        // shadow + frame
+        ctx.fillStyle = 'rgba(24,24,24,0.25)';
+        this.rr(ctx, px + 4, py + 4, pw, ph, 12); ctx.fill();
+        ctx.fillStyle = '#181818';
+        this.rr(ctx, px, py, pw, ph, 12); ctx.fill();
+        ctx.fillStyle = C.UI_BG;
+        this.rr(ctx, px + 4, py + 4, pw - 8, ph - 8, 9); ctx.fill();
+
+        // name + level
+        ctx.fillStyle = '#181818';
+        ctx.font = 'bold 18px monospace';
+        ctx.fillText(train.nickname || train.species.name, px + 16, py + 28);
+        ctx.font = 'bold 14px monospace';
+        ctx.textAlign = 'right';
+        ctx.fillText(`Lv${train.level}`, px + pw - 14, py + 28);
+        ctx.textAlign = 'left';
+
+        // status badge (PAR/BRN/PSN)
+        if (train.status) {
+            const tag = { paralyze: 'PAR', burn: 'BRN', poison: 'PSN' }[train.status] || '';
+            const col = { paralyze: '#F8C838', burn: '#F83048', poison: '#A040A0' }[train.status] || '#888';
+            ctx.fillStyle = col;
+            this.rr(ctx, px + 16, py + 34, 40, 16, 4); ctx.fill();
+            ctx.fillStyle = '#fff'; ctx.font = 'bold 11px monospace';
+            ctx.fillText(tag, px + 22, py + 46);
+        }
+
+        // HP bar
+        const barX = px + (train.status ? 64 : 16), barY = py + 38, barW = pw - (barX - px) - 16, barH = 12;
+        const pct = Math.max(0, train.currentHP / train.maxHP);
+        ctx.fillStyle = '#181818';
+        this.rr(ctx, barX - 2, barY - 2, barW + 4, barH + 4, 4); ctx.fill();
+        ctx.fillStyle = C.HP_BG;
+        this.rr(ctx, barX, barY, barW, barH, 3); ctx.fill();
+        ctx.fillStyle = this.hpColor(pct);
+        if (pct > 0) { this.rr(ctx, barX, barY, barW * pct, barH, 3); ctx.fill(); }
+
+        // type chips
+        let chipX = px + 16;
+        const chipY = py + 58;
+        ctx.font = 'bold 10px monospace';
+        for (const t of train.types) {
+            const cw = ctx.measureText(t).width + 14;
+            ctx.fillStyle = CONSTANTS.TYPE_COLORS[t] || '#888';
+            this.rr(ctx, chipX, chipY, cw, 16, 4); ctx.fill();
+            ctx.fillStyle = '#fff';
+            ctx.fillText(t, chipX + 7, chipY + 12);
+            chipX += cw + 6;
+        }
+
+        if (showNumbers) {
+            ctx.fillStyle = '#181818';
+            ctx.font = 'bold 12px monospace';
+            ctx.textAlign = 'right';
+            ctx.fillText(`${train.currentHP}/${train.maxHP}`, px + pw - 14, py + 70);
+            ctx.textAlign = 'left';
+        }
+    }
+
+    drawMenuGrid(ctx, items, selectedIndex, colorFor) {
+        const C = CONSTANTS.COLORS;
+        const menuX = 408, menuY = 566, bw = 162, bh = 40, gap = 6;
+        items.forEach((label, index) => {
+            if (!label) return;
+            const x = menuX + (index % 2) * (bw + gap);
+            const y = menuY + Math.floor(index / 2) * (bh + gap);
+            const sel = index === selectedIndex;
+            const accent = colorFor ? colorFor(index) : C.UI_HIGHLIGHT;
+            ctx.fillStyle = '#181818';
+            this.rr(ctx, x, y, bw, bh, 8); ctx.fill();
+            ctx.fillStyle = sel ? accent : C.WHITE;
+            this.rr(ctx, x + 3, y + 3, bw - 6, bh - 6, 6); ctx.fill();
+            // selection cursor
+            if (sel) {
+                ctx.fillStyle = '#181818';
+                ctx.font = 'bold 16px monospace';
+                ctx.fillText('>', x + 10, y + bh / 2 + 6);
+            }
+            ctx.fillStyle = sel ? '#fff' : '#181818';
+            ctx.font = 'bold 15px monospace';
+            ctx.textAlign = 'center';
+            ctx.fillText(label, x + bw / 2 + 6, y + bh / 2 + 6);
+            ctx.textAlign = 'left';
+        });
+    }
+
     render(ctx) {
         const canvas = ctx.canvas;
+        const C = CONSTANTS.COLORS;
 
-        // Pokemon-style solid cream background
-        ctx.fillStyle = CONSTANTS.COLORS.UI_BG;
+        // Backdrop: sky gradient + ground band
+        const sky = ctx.createLinearGradient(0, 0, 0, canvas.height);
+        sky.addColorStop(0, C.BATTLE_SKY2);
+        sky.addColorStop(1, C.BATTLE_SKY);
+        ctx.fillStyle = sky;
         ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = C.BATTLE_GROUND;
+        ctx.fillRect(0, 372, canvas.width, canvas.height - 372);
 
-        // Calculate animation offsets
-        const enemyShakeX = this.enemyShake > 0 ? Math.sin(Date.now() * 0.05) * this.enemyShake * 2 : 0;
-        const playerShakeX = this.playerShake > 0 ? Math.sin(Date.now() * 0.05) * this.playerShake * 2 : 0;
+        // Battle platforms (oval pads under each combatant)
+        ctx.fillStyle = C.BATTLE_PLATFORM;
+        ctx.beginPath(); ctx.ellipse(604, 280, 132, 30, 0, 0, Math.PI * 2); ctx.fill();
+        ctx.beginPath(); ctx.ellipse(196, 452, 156, 36, 0, 0, Math.PI * 2); ctx.fill();
 
-        // Pokemon-style sprite positioning
-        // Enemy train sprite (upper right, front-facing)
+        // deltaTime-driven shake (no Date.now())
+        const enemyShakeX = this.enemyShake > 0 ? Math.sin(this.animationTimer * 40) * this.enemyShake * 2 : 0;
+        const playerShakeX = this.playerShake > 0 ? Math.sin(this.animationTimer * 40) * this.playerShake * 2 : 0;
+
         if (this.enemyActive) {
-            // Flash effect when taking damage
+            this.drawEnemyTrain(ctx, 540 + enemyShakeX, 150);
             if (this.enemyFlash > 0) {
-                ctx.globalAlpha = 0.5 + (this.enemyFlash * 0.5);
-                ctx.fillStyle = CONSTANTS.COLORS.HP_RED;
-                ctx.fillRect(500 + enemyShakeX - 10, 140 - 10, 100, 100);
+                ctx.globalAlpha = this.enemyFlash * 0.5;
+                ctx.fillStyle = C.HP_RED;
+                ctx.fillRect(540 + enemyShakeX, 150, 128, 128);
                 ctx.globalAlpha = 1.0;
             }
-            this.drawEnemyTrain(ctx, 500 + enemyShakeX, 140);
+            this.drawStatusPanel(ctx, this.enemyActive, 36, 40, 320, false);
         }
 
-        // Player train sprite (lower left, back-facing)
         if (this.playerActive) {
-            // Flash effect when taking damage
+            this.drawPlayerTrain(ctx, 132 + playerShakeX, 312);
             if (this.playerFlash > 0) {
-                ctx.globalAlpha = 0.5 + (this.playerFlash * 0.5);
-                ctx.fillStyle = CONSTANTS.COLORS.HP_RED;
-                ctx.fillRect(120 + playerShakeX - 10, 320 - 10, 100, 100);
+                ctx.globalAlpha = this.playerFlash * 0.5;
+                ctx.fillStyle = C.HP_RED;
+                ctx.fillRect(132 + playerShakeX, 312, 128, 128);
                 ctx.globalAlpha = 1.0;
             }
-            this.drawPlayerTrain(ctx, 120 + playerShakeX, 320);
+            this.drawStatusPanel(ctx, this.playerActive, canvas.width - 356, 452, 320, true);
         }
 
-        // Pokemon-style enemy info panel (top-left)
-        if (this.enemyActive) {
-            // Panel background
-            ctx.fillStyle = CONSTANTS.COLORS.WHITE;
-            ctx.fillRect(40, 30, 320, 80);
-            ctx.strokeStyle = CONSTANTS.COLORS.BLACK;
-            ctx.lineWidth = 3;
-            ctx.strokeRect(40, 30, 320, 80);
+        // Message box (framed, bottom full-width)
+        ctx.fillStyle = '#181818';
+        this.rr(ctx, 16, 556, canvas.width - 32, 100, 14); ctx.fill();
+        ctx.fillStyle = C.UI_BG;
+        this.rr(ctx, 22, 562, canvas.width - 44, 88, 10); ctx.fill();
 
-            // Name and level
-            ctx.fillStyle = CONSTANTS.COLORS.BLACK;
-            ctx.font = '20px monospace';
-            ctx.fillText(this.enemyActive.nickname || this.enemyActive.species.name, 55, 58);
-            ctx.font = '16px monospace';
-            ctx.fillText(`Lv${this.enemyActive.level}`, 290, 58);
-
-            // HP label
-            ctx.font = '14px monospace';
-            ctx.fillText('HP:', 55, 85);
-
-            // Enemy HP bar (Pokemon Gen 1 style - no numbers shown)
-            const enemyHPPercent = this.enemyActive.currentHP / this.enemyActive.maxHP;
-            ctx.fillStyle = CONSTANTS.COLORS.HP_BG;
-            ctx.fillRect(95, 73, 240, 16);
-
-            // HP bar fill with authentic Pokemon colors
-            if (enemyHPPercent > 0.5) {
-                ctx.fillStyle = CONSTANTS.COLORS.HP_GREEN;
-            } else if (enemyHPPercent > 0.2) {
-                ctx.fillStyle = CONSTANTS.COLORS.HP_YELLOW;
-            } else {
-                ctx.fillStyle = CONSTANTS.COLORS.HP_RED;
-            }
-            ctx.fillRect(95, 73, 240 * enemyHPPercent, 16);
-            ctx.strokeStyle = CONSTANTS.COLORS.BLACK;
-            ctx.lineWidth = 2;
-            ctx.strokeRect(95, 73, 240, 16);
-        }
-
-        // Pokemon-style player info panel (bottom-right)
-        if (this.playerActive) {
-            // Panel background
-            ctx.fillStyle = CONSTANTS.COLORS.WHITE;
-            ctx.fillRect(408, 450, 340, 100);
-            ctx.strokeStyle = CONSTANTS.COLORS.BLACK;
-            ctx.lineWidth = 3;
-            ctx.strokeRect(408, 450, 340, 100);
-
-            // Name and level
-            ctx.fillStyle = CONSTANTS.COLORS.BLACK;
-            ctx.font = '20px monospace';
-            ctx.fillText(this.playerActive.nickname || this.playerActive.species.name, 425, 478);
-            ctx.font = '16px monospace';
-            ctx.fillText(`Lv${this.playerActive.level}`, 680, 478);
-
-            // HP label
-            ctx.font = '14px monospace';
-            ctx.fillText('HP:', 425, 508);
-
-            // Player HP bar
-            const playerHPPercent = this.playerActive.currentHP / this.playerActive.maxHP;
-            ctx.fillStyle = CONSTANTS.COLORS.HP_BG;
-            ctx.fillRect(465, 496, 260, 16);
-
-            // HP bar fill with authentic Pokemon colors
-            if (playerHPPercent > 0.5) {
-                ctx.fillStyle = CONSTANTS.COLORS.HP_GREEN;
-            } else if (playerHPPercent > 0.2) {
-                ctx.fillStyle = CONSTANTS.COLORS.HP_YELLOW;
-            } else {
-                ctx.fillStyle = CONSTANTS.COLORS.HP_RED;
-            }
-            ctx.fillRect(465, 496, 260 * playerHPPercent, 16);
-            ctx.strokeStyle = CONSTANTS.COLORS.BLACK;
-            ctx.lineWidth = 2;
-            ctx.strokeRect(465, 496, 260, 16);
-
-            // HP numbers (shown for player's Pokemon in Gen 1)
-            ctx.fillStyle = CONSTANTS.COLORS.BLACK;
-            ctx.font = '14px monospace';
-            ctx.textAlign = 'right';
-            ctx.fillText(`${this.playerActive.currentHP}/ ${this.playerActive.maxHP}`, 720, 532);
-            ctx.textAlign = 'left'; // Reset alignment
-        }
-
-        // Pokemon-style message box (bottom, full width)
-        ctx.fillStyle = CONSTANTS.COLORS.WHITE;
-        ctx.fillRect(20, 560, canvas.width - 40, 90);
-        ctx.strokeStyle = CONSTANTS.COLORS.BLACK;
-        ctx.lineWidth = 3;
-        ctx.strokeRect(20, 560, canvas.width - 40, 90);
-
-        // Display current message with Pokemon font
-        ctx.fillStyle = CONSTANTS.COLORS.BLACK;
+        ctx.fillStyle = '#181818';
         ctx.font = '18px monospace';
         if (this.messages.length > 0 && this.currentMessage < this.messages.length) {
-            const message = this.messages[this.currentMessage];
-            this.wrapText(ctx, message, 40, 590, canvas.width - 80, 24);
+            this.wrapText(ctx, this.messages[this.currentMessage], 40, 592, canvas.width - 360, 24);
         }
 
-        // Pokemon-style 2x2 battle menu (overlays right side of message box)
+        // Action menu (FIGHT/TRAIN/ITEM/RUN)
         if (this.state === CONSTANTS.BATTLE_STATES.MENU) {
-            const menuOptions = ['FIGHT', 'TRAIN', 'ITEM', 'RUN'];
-            const menuX = 420;
-            const menuY = 565;
-            const buttonWidth = 155;
-            const buttonHeight = 38;
-
-            menuOptions.forEach((option, index) => {
-                const x = menuX + (index % 2) * (buttonWidth + 5);
-                const y = menuY + Math.floor(index / 2) * (buttonHeight + 4);
-
-                // Pokemon-style button styling
-                ctx.fillStyle = index === this.menuSelection ? CONSTANTS.COLORS.UI_HIGHLIGHT : CONSTANTS.COLORS.WHITE;
-                ctx.fillRect(x, y, buttonWidth, buttonHeight);
-                ctx.strokeStyle = CONSTANTS.COLORS.BLACK;
-                ctx.lineWidth = 3;
-                ctx.strokeRect(x, y, buttonWidth, buttonHeight);
-
-                // Button text
-                ctx.fillStyle = index === this.menuSelection ? CONSTANTS.COLORS.WHITE : CONSTANTS.COLORS.BLACK;
-                ctx.font = 'bold 16px monospace';
-                ctx.textAlign = 'center';
-                ctx.fillText(option, x + buttonWidth / 2, y + buttonHeight / 2 + 6);
-                ctx.textAlign = 'left'; // Reset alignment
-            });
+            this.drawMenuGrid(ctx, ['FIGHT', 'TRAIN', 'ITEM', 'RUN'], this.menuSelection);
         }
 
-        // Pokemon-style move selection menu (2x2 grid)
+        // Move menu - each button tinted by the move's type.
         if (this.state === CONSTANTS.BATTLE_STATES.FIGHT) {
             const moves = this.playerActive.moves;
-            const menuX = 420;
-            const menuY = 565;
-            const buttonWidth = 155;
-            const buttonHeight = 38;
+            this.drawMenuGrid(ctx, moves.map(m => typeof m === 'string' ? m : m.name), this.moveSelection,
+                (i) => {
+                    const md = MOVES_DB[moves[i]];
+                    return (md && CONSTANTS.TYPE_COLORS[md.type]) || CONSTANTS.COLORS.UI_HIGHLIGHT;
+                });
+        }
+    }
 
-            moves.forEach((move, index) => {
-                if (move) {
-                    const x = menuX + (index % 2) * (buttonWidth + 5);
-                    const y = menuY + Math.floor(index / 2) * (buttonHeight + 4);
+    // Stylized locomotive fallback art (steam-engine palette). facing 'front'
+    // points the cab/buffer toward the player; 'back' faces away.
+    drawLoco(ctx, x, y, facing) {
+        const C = CONSTANTS.COLORS;
+        const front = facing === 'front';
+        const w = 124, bodyY = y + 36, bodyH = 46;
 
-                    // Pokemon-style button styling
-                    ctx.fillStyle = index === this.moveSelection ? CONSTANTS.COLORS.UI_HIGHLIGHT : CONSTANTS.COLORS.WHITE;
-                    ctx.fillRect(x, y, buttonWidth, buttonHeight);
-                    ctx.strokeStyle = CONSTANTS.COLORS.BLACK;
-                    ctx.lineWidth = 3;
-                    ctx.strokeRect(x, y, buttonWidth, buttonHeight);
+        // contact shadow
+        ctx.fillStyle = 'rgba(24,24,24,0.22)';
+        ctx.beginPath(); ctx.ellipse(x + w / 2, y + 116, 58, 12, 0, 0, Math.PI * 2); ctx.fill();
 
-                    // Move name text
-                    const moveName = typeof move === 'string' ? move : move.name;
-                    ctx.fillStyle = index === this.moveSelection ? CONSTANTS.COLORS.WHITE : CONSTANTS.COLORS.BLACK;
-                    ctx.font = 'bold 14px monospace';
-                    ctx.textAlign = 'center';
-                    ctx.fillText(moveName, x + buttonWidth / 2, y + buttonHeight / 2 + 5);
-                    ctx.textAlign = 'left'; // Reset alignment
-                }
-            });
+        // boiler body
+        ctx.fillStyle = C.LOCO_BODY;
+        ctx.fillRect(x + 8, bodyY, w - 16, bodyH);
+        ctx.fillStyle = C.LOCO_BODY_DARK;
+        ctx.fillRect(x + 8, bodyY + bodyH - 8, w - 16, 8); // underside shade
+        ctx.fillStyle = 'rgba(255,255,255,0.12)';
+        ctx.fillRect(x + 8, bodyY, w - 16, 6); // top sheen
+
+        // cab (rear)
+        const cabX = front ? x + w - 42 : x + 6;
+        ctx.fillStyle = C.LOCO_BODY_DARK;
+        ctx.fillRect(cabX, y + 14, 36, bodyH + 6);
+        ctx.fillStyle = '#9CD0E8'; // cab window
+        ctx.fillRect(cabX + 7, y + 22, 22, 16);
+
+        // smokestack + dome (front)
+        const stackX = front ? x + 20 : x + w - 34;
+        ctx.fillStyle = C.LOCO_IRON_DARK;
+        ctx.fillRect(stackX, y + 6, 14, 32);
+        ctx.fillStyle = C.LOCO_BRASS;
+        ctx.fillRect(stackX - 2, y + 4, 18, 6); // stack rim
+        ctx.fillStyle = C.LOCO_BRASS;
+        ctx.beginPath(); ctx.arc(x + w / 2, bodyY + 6, 8, Math.PI, 0); ctx.fill(); // steam dome
+
+        // front buffer beam + headlight (only when facing us)
+        if (front) {
+            ctx.fillStyle = C.LOCO_IRON_DARK;
+            ctx.fillRect(x, bodyY + 6, 10, bodyH - 6);
+            ctx.fillStyle = C.LOCO_BRASS;
+            ctx.beginPath(); ctx.arc(x + 6, bodyY + bodyH / 2, 6, 0, Math.PI * 2); ctx.fill(); // headlight
+            ctx.fillStyle = C.LOCO_RED;
+            ctx.fillRect(x + 8, bodyY + bodyH - 14, w - 16, 5); // red accent stripe
+        }
+
+        // wheels
+        ctx.fillStyle = C.LOCO_IRON;
+        for (let i = 0; i < 3; i++) {
+            const wx = x + 24 + i * 34;
+            ctx.beginPath(); ctx.arc(wx, bodyY + bodyH, 11, 0, Math.PI * 2); ctx.fill();
+            ctx.fillStyle = C.LOCO_IRON_DARK;
+            ctx.beginPath(); ctx.arc(wx, bodyY + bodyH, 4, 0, Math.PI * 2); ctx.fill();
+            ctx.fillStyle = C.LOCO_IRON;
+        }
+
+        // steam puffs from the stack
+        ctx.fillStyle = 'rgba(232,232,232,0.85)';
+        for (let i = 0; i < 3; i++) {
+            const t = this.animationTimer + i;
+            ctx.beginPath();
+            ctx.arc(stackX + 7 + Math.sin(t) * 5, y + 2 - i * 9, 5 + i * 2, 0, Math.PI * 2);
+            ctx.fill();
         }
     }
 
     drawEnemyTrain(ctx, x, y) {
-        // Red train facing left (front view)
-        ctx.fillStyle = '#D32F2F';
-        ctx.fillRect(x, y + 20, 80, 40); // Main body
-        ctx.fillStyle = '#C62828';
-        ctx.fillRect(x + 10, y, 20, 25); // Smoke stack
-        ctx.fillStyle = '#424242';
-        ctx.beginPath();
-        ctx.arc(x + 20, y + 70, 10, 0, Math.PI * 2); // Front wheel
-        ctx.arc(x + 60, y + 70, 10, 0, Math.PI * 2); // Back wheel
-        ctx.fill();
-        ctx.fillStyle = '#FFEB3B';
-        ctx.fillRect(x + 5, y + 30, 12, 12); // Window
+        const sprite = this.game.images[`${this.enemyActive.species.name}_front`];
+        if (sprite && sprite.complete && sprite.naturalWidth > 0) {
+            ctx.drawImage(sprite, x, y, 128, 128);
+        } else {
+            this.drawLoco(ctx, x, y, 'front');
+        }
     }
 
     drawPlayerTrain(ctx, x, y) {
-        // Blue train facing right (back view)
-        ctx.fillStyle = '#1976D2';
-        ctx.fillRect(x, y + 20, 80, 40); // Main body
-        ctx.fillStyle = '#1565C0';
-        ctx.fillRect(x + 50, y, 20, 25); // Smoke stack
-        ctx.fillStyle = '#424242';
-        ctx.beginPath();
-        ctx.arc(x + 20, y + 70, 10, 0, Math.PI * 2); // Front wheel
-        ctx.arc(x + 60, y + 70, 10, 0, Math.PI * 2); // Back wheel
-        ctx.fill();
-        ctx.fillStyle = '#FFEB3B';
-        ctx.fillRect(x + 63, y + 30, 12, 12); // Window
+        const sprite = this.game.images[`${this.playerActive.species.name}_back`];
+        if (sprite && sprite.complete && sprite.naturalWidth > 0) {
+            ctx.drawImage(sprite, x, y, 128, 128);
+        } else {
+            this.drawLoco(ctx, x, y, 'back');
+        }
     }
 
     wrapText(ctx, text, x, y, maxWidth, lineHeight) {

--- a/js/constants.js
+++ b/js/constants.js
@@ -49,7 +49,41 @@ const CONSTANTS = {
         GRASS_LIGHT: '#58D878',
         GRASS_DARK: '#309850',
         WATER: '#5890D0',
-        PATH: '#C8B898'
+        PATH: '#C8B898',
+
+        LIGHT_GRAY: '#C8C8A0',
+
+        // Cohesive overworld tile palette (muted GBC, two tones per material
+        // so tiles read as textured rather than flat fills).
+        GRASS_BASE: '#7BB662',
+        GRASS_ALT: '#6AA552',
+        GRASS_SPECK: '#5C9447',
+        TALLGRASS_BASE: '#4F9A4B',
+        TALLGRASS_ALT: '#3F8540',
+        PATH_BASE: '#D8C7A0',
+        PATH_ALT: '#C8A882',
+        PATH_EDGE: '#B8924E',
+        WATER_BASE: '#5878A8',
+        WATER_ALT: '#6E8CC0',
+        WALL_BASE: '#6B4226',
+        WALL_ALT: '#4A2818',
+        RAIL_BASE: '#5C5C5C',
+        RAIL_TIE: '#3A3A3A',
+        DOOR_BASE: '#8B5A3C',
+
+        // Battle backdrop + locomotive fallback art (steam-engine palette from
+        // ART_DIRECTION_SPECS.md).
+        BATTLE_SKY: '#9CD0E8',
+        BATTLE_SKY2: '#BCE0F0',
+        BATTLE_GROUND: '#C8A882',
+        BATTLE_PLATFORM: '#A67C52',
+        LOCO_BODY: '#6B4226',
+        LOCO_BODY_DARK: '#4A2818',
+        LOCO_BRASS: '#D4A857',
+        LOCO_IRON: '#5C5C5C',
+        LOCO_IRON_DARK: '#3A3A3A',
+        LOCO_RED: '#D64545',
+        LOCO_STEAM: '#E8E8E8'
     },
 
     // Game states

--- a/js/game.js
+++ b/js/game.js
@@ -6,12 +6,17 @@
 function Game(canvas) {
     this.canvas = canvas;
     this.ctx = canvas.getContext('2d');
+    // Pixel-art: disable bilinear smoothing so upscaled 16px tiles/sprites stay
+    // crisp (matches the stated GB-era art spec).
+    this.ctx.imageSmoothingEnabled = false;
     this.state = 'loading'; // Start in loading state
 
     // Core systems
     this.input = new InputHandler();
     this.player = new Player();
     this.ui = new UI(this.ctx);
+    this.dialogueBox = new DialogueBox();
+    this.audio = new AudioManager();
 
     // Map system
     this.currentMap = null;
@@ -28,6 +33,10 @@ function Game(canvas) {
     this.imagesLoaded = false;
     this.loadingProgress = 0;
 
+    // Visual-only flags / animation clocks (no gameplay effect).
+    this.debug = false;        // set true to show the Map/Pos developer overlay
+    this.animClock = 0;        // seconds, drives subtle idle animations
+
     // Debug menu
     this.debugMenuSelection = 0;
     this.debugMenuOptions = [
@@ -36,6 +45,9 @@ function Game(canvas) {
         { label: 'Starter Selection', state: CONSTANTS.STATES.STARTER_SELECTION },
         { label: 'Overworld (Piston Town)', state: CONSTANTS.STATES.OVERWORLD },
         { label: 'Wild Battle', action: 'wildBattle' },
+        { label: 'Gym Leader Battle', action: 'gymBattle' },
+        { label: 'Victory Road (High Lv)', action: 'victoryRoad' },
+        { label: 'Heal Party', action: 'heal' },
         { label: 'Close Debug Menu', action: 'close' }
     ];
 
@@ -47,14 +59,16 @@ function Game(canvas) {
     this.selectedItem = null;
     this.trainSelection = 0;
 
-    // Shop system
+    // Shop system - catalog derived from the Items registry (single source of
+    // truth). UI expects {name, displayName, price, description}.
     this.shopSelection = 0;
     this.shopMode = null;  // null or 'active' when shop is open
-    this.shopItems = [
-        { name: 'potion', displayName: 'Potion', price: 300, description: 'Heals 20 HP' },
-        { name: 'super_potion', displayName: 'Super Potion', price: 700, description: 'Heals 50 HP' },
-        { name: 'boxcar', displayName: 'Boxcar', price: 200, description: 'Catches wild trains' }
-    ];
+    this.shopItems = Items.shopInventory().map(item => ({
+        name: item.id,
+        displayName: item.name,
+        price: item.price,
+        description: item.description
+    }));
 
     // Initialize maps and assets
     this.initAssets();
@@ -63,12 +77,32 @@ function Game(canvas) {
     console.log('✅ Game initialized');
 }
 
-Game.prototype.initAssets = async function() {
-    await this.initMaps();
-    this.preloadStarterSprites(); // This can run in parallel
+Game.prototype.initAssets = async function () {
+    console.log('Starting asset loading...');
+    try {
+        // Setup maps synchronously FIRST
+        this.setupMaps();
+
+        // Start sprite loading immediately (non-blocking)
+        this.preloadAssets();
+
+        // Start tileset loading (non-blocking)
+        this.loadTilesets().then(() => {
+            console.log('Tilesets loaded');
+        }).catch(e => {
+            console.error('Tileset load failed:', e);
+        });
+
+    } catch (e) {
+        console.error('Error in initAssets:', e);
+    }
+
+    // Resolve immediately to let game loop start
+    return Promise.resolve();
 };
 
-Game.prototype.initMaps = async function() {
+Game.prototype.setupMaps = function () {
+    console.log('🗺️ Setting up maps...');
     // Create starter map (legacy from map.js)
     this.maps['pallet_town'] = createStarterMap();
 
@@ -77,82 +111,89 @@ Game.prototype.initMaps = async function() {
         for (const mapId in WORLD_MAPS) {
             this.maps[mapId] = WORLD_MAPS[mapId];
         }
+    } else {
+        console.error('❌ WORLD_MAPS is undefined!');
     }
 
-    // Legacy: Coal Harbor Gym now loaded from WORLD_MAPS above
-    // (coal_harbor_gym.js is deprecated - gym integrated into world-maps.js)
+    // Set current map IMMEDIATELY after populating maps
+    if (this.maps['PistonTown']) {
+        this.currentMap = this.maps['PistonTown'];
+        console.log('✅ Set initial map to PistonTown');
+    } else {
+        this.currentMap = this.maps['pallet_town'];
+        console.log('⚠️ Set initial map to pallet_town (fallback)');
+    }
+};
 
+Game.prototype.loadTilesets = async function () {
+    console.log('🎨 Loading tilesets...');
     // Load all tilesets
     for (const mapId in this.maps) {
         const map = this.maps[mapId];
         if (map.tileset) {
-            console.log(`Loading tileset for ${mapId}: ${map.tileset}`);
+            // console.log(`Loading tileset for ${mapId}: ${map.tileset}`);
             try {
                 const tileset = await loadTileset({ src: map.tileset });
                 this.tilesets[mapId] = tileset;
                 map.tilesetRef = tileset; // Add a direct reference to the map object
-                console.log(`✅ Tileset loaded for ${mapId}`);
+                // console.log(`✅ Tileset loaded for ${mapId}`);
             } catch (error) {
                 console.error(`❌ Failed to load tileset for ${mapId}:`, error);
             }
         }
     }
+    console.log('✅ All tilesets loaded');
+};
 
-    // Set current map after loading
-    if (this.maps['PistonTown']) {
-        this.currentMap = this.maps['PistonTown'];
-    } else {
-        this.currentMap = this.maps['pallet_town'];
+// Preload the sprites that actually ship as assets. Only the three starter
+// species use the {Name}/front.png + back.png layout the battle renderer reads;
+// every other train falls back to procedural art. Images load asynchronously
+// and are looked up lazily at draw time (sprite.complete is checked there), so
+// this never blocks boot - main.js drives the loading -> title transition.
+//
+// (Replaces the old preloadStarterSprites/initMaps, which referenced an
+// undefined `trains` global and a misnamed method, so preloading never ran.)
+Game.prototype.preloadAssets = function () {
+    const SPRITE_SPECIES = ['Steamini', 'Sparkart', 'Diesling'];
+
+    const load = (key, src) => {
+        const img = new Image();
+        img.src = src;
+        this.images[key] = img;
+    };
+
+    for (const name of SPRITE_SPECIES) {
+        load(name, `assets/sprites/${name}/front.png`);          // starter-select screen uses [name]
+        load(`${name}_front`, `assets/sprites/${name}/front.png`);
+        load(`${name}_back`, `assets/sprites/${name}/back.png`);
+    }
+
+    this.imagesLoaded = true;
+    this.loadingProgress = 1;
+};
+
+// Central state transition. Clears any stale "just pressed" input so a key
+// buffered during one state can't auto-trigger an action in the next, and runs
+// per-state entry setup in one place.
+Game.prototype.setState = function (next) {
+    this.state = next;
+    if (this.input) this.input.reset();
+
+    switch (next) {
+        case CONSTANTS.STATES.MENU:
+            this.menuSelection = 0;
+            this.bagMode = null;
+            this.shopMode = null;
+            this.selectedItem = null;
+            break;
+        case CONSTANTS.STATES.BATTLE_SUMMARY:
+            // caughtTrainResult is set by the caller before transitioning.
+            break;
     }
 };
 
-Game.prototype.preloadStarterSprites = function() {
-    const starters = ['Steamini', 'Sparkart', 'Diesling'];
-    const characters = ['professor-cypress-1']; // Character sprites to load
-    const allImages = [...starters, ...characters];
-    let loadedCount = 0;
-    const totalImages = allImages.length;
-
-    const onImageLoad = (name) => {
-        loadedCount++;
-        this.loadingProgress = loadedCount / totalImages;
-        console.log(`✅ Loaded ${name} (${loadedCount}/${totalImages})`);
-        if (loadedCount === totalImages) {
-            this.imagesLoaded = true;
-            // Only transition to title if we're in loading state (not if we loaded from save)
-            if (this.state === 'loading') {
-                this.state = CONSTANTS.STATES.TITLE;
-            }
-            console.log('✅ All sprites loaded');
-        }
-    };
-
-    const onImageError = (name) => {
-        console.error(`❌ Failed to load sprite: ${name}`);
-        loadedCount++;
-        this.loadingProgress = loadedCount / totalImages;
-    };
-
-    // Load starter sprites
-    for (const starter of starters) {
-        const img = new Image();
-        img.onload = () => onImageLoad(starter);
-        img.onerror = () => onImageError(starter);
-        img.src = `assets/sprites/${starter}/front.png`;
-        this.images[starter] = img;
-    }
-
-    // Load character sprites
-    for (const character of characters) {
-        const img = new Image();
-        img.onload = () => onImageLoad(character);
-        img.onerror = () => onImageError(character);
-        img.src = `assets/sprites/characters/${character}.png`;
-        this.images[character] = img;
-    }
-};
-
-Game.prototype.update = function(deltaTime) {
+Game.prototype.update = function (deltaTime) {
+    this.animClock += deltaTime || 0; // visual-only clock for idle animations
     switch (this.state) {
         case 'loading':
             // Images are loading, wait for completion
@@ -178,13 +219,24 @@ Game.prototype.update = function(deltaTime) {
         case CONSTANTS.STATES.MENU:
             this.updateMenu();
             break;
+        case CONSTANTS.STATES.DIALOGUE:
+            this.updateDialogue(deltaTime);
+            break;
         case 'debug':
             this.updateDebugMenu();
             break;
     }
 };
 
-Game.prototype.updateTitle = function() {
+Game.prototype.updateDialogue = function (deltaTime) {
+    this.dialogueBox.update(deltaTime);
+
+    if (this.input.isKeyJustPressed('Enter') || this.input.isKeyJustPressed('z') || this.input.isVirtualKeyJustPressed('a')) {
+        this.dialogueBox.advance();
+    }
+};
+
+Game.prototype.updateTitle = function () {
     // Debug menu shortcut
     if (this.input.isKeyJustPressed('`') || this.input.isKeyJustPressed('F1')) {
         this.state = 'debug';
@@ -193,13 +245,21 @@ Game.prototype.updateTitle = function() {
     }
 
     if (this.input.isKeyJustPressed('Enter') || this.input.isVirtualKeyJustPressed('a')) {
-        this.state = CONSTANTS.STATES.INTRO;
-        this.introScene = new IntroScene();
-        console.log('→ INTRO');
+        // Resume an existing save straight into the overworld; otherwise start
+        // the new-game intro. (We no longer persist `state`, so the decision is
+        // made here from whether a save with a party was loaded.)
+        if (this.loadedSave && this.player.party && this.player.party.length > 0) {
+            this.setState(CONSTANTS.STATES.OVERWORLD);
+            console.log('→ OVERWORLD (resumed save)');
+        } else {
+            this.state = CONSTANTS.STATES.INTRO;
+            this.introScene = new IntroScene();
+            console.log('→ INTRO');
+        }
     }
 };
 
-Game.prototype.updateDebugMenu = function() {
+Game.prototype.updateDebugMenu = function () {
     // Navigation
     if (this.input.isKeyJustPressed('ArrowUp') || this.input.isVirtualKeyJustPressed('up')) {
         this.debugMenuSelection = (this.debugMenuSelection - 1 + this.debugMenuOptions.length) % this.debugMenuOptions.length;
@@ -228,9 +288,50 @@ Game.prototype.updateDebugMenu = function() {
             // Trigger wild encounter
             const wildTrainId = Math.floor(Math.random() * 10) + 1; // Random from IDs 1-10
             const wildTrain = new Train(wildTrainId, 5);
-            this.battle = new Battle(this.player.party, [wildTrain]);
+            this.battle = new Battle(this, this.player.party, [wildTrain]);
             this.state = CONSTANTS.STATES.BATTLE;
             console.log('→ WILD BATTLE (debug)');
+            return;
+        }
+
+        if (option.action === 'gymBattle') {
+            this.state = CONSTANTS.STATES.OVERWORLD;
+            // Ensure player has a starter
+            if (!this.player.party || this.player.party.length === 0) {
+                this.player.party = [new Train(1, 15)]; // Steamini Lv 15
+            }
+
+            // Find Gym Leader Marina in Coal Harbor Gym data
+            // We need to access the map data directly since we might not be in the gym
+            const gymMap = this.maps['CoalHarborGym'] || WORLD_MAPS['CoalHarborGym'];
+            const marina = gymMap.npcs.find(n => n.id === 'gym_leader_marina');
+
+            if (marina) {
+                this.startTrainerBattle(marina);
+            } else {
+                console.error('Gym Leader Marina not found!');
+            }
+            return;
+        }
+
+        if (option.action === 'victoryRoad') {
+            this.state = CONSTANTS.STATES.OVERWORLD;
+            if (!this.player.party || this.player.party.length === 0) {
+                this.player.party = [new Train(3, 40)]; // Diesling Lv 40
+            }
+            // High level wild encounter
+            const wildTrainId = Math.floor(Math.random() * 5) + 10; // Later IDs
+            const wildTrain = new Train(wildTrainId, 45);
+            this.battle = new Battle(this, this.player.party, [wildTrain]);
+            this.state = CONSTANTS.STATES.BATTLE;
+            console.log('→ VICTORY ROAD BATTLE (debug)');
+            return;
+        }
+
+        if (option.action === 'heal') {
+            this.player.healParty();
+            console.log('→ PARTY HEALED');
+            this.state = CONSTANTS.STATES.OVERWORLD;
             return;
         }
 
@@ -270,7 +371,7 @@ Game.prototype.updateDebugMenu = function() {
     }
 };
 
-Game.prototype.updateIntro = function() {
+Game.prototype.updateIntro = function () {
     // Allow B to go back through intro or return to title
     if (this.input.isKeyJustPressed('Backspace') || this.input.isKeyJustPressed('x') || this.input.isVirtualKeyJustPressed('b')) {
         if (this.introScene.currentIndex > 0) {
@@ -291,7 +392,7 @@ Game.prototype.updateIntro = function() {
     }
 };
 
-Game.prototype.updateStarterSelection = function() {
+Game.prototype.updateStarterSelection = function () {
     const ss = this.starterSelection;
 
     // Handle input based on phase
@@ -334,10 +435,17 @@ Game.prototype.updateStarterSelection = function() {
         if (this.input.isKeyJustPressed('Backspace') || this.input.isKeyJustPressed('x') || this.input.isVirtualKeyJustPressed('b')) {
             ss.phase = 'selection';
             ss.confirmed = false;
-            console.log('Cancelled from post-selection - back to selection');
         } else if (this.input.isKeyJustPressed('Enter') || this.input.isKeyJustPressed('z') || this.input.isVirtualKeyJustPressed('a')) {
             const complete = ss.advancePostSelection();
             if (complete) {
+                if (!this.currentMap) {
+                    if (this.maps['PistonTown']) {
+                        this.currentMap = this.maps['PistonTown'];
+                    } else if (typeof WORLD_MAPS !== 'undefined' && WORLD_MAPS['PistonTown']) {
+                        this.currentMap = WORLD_MAPS['PistonTown'];
+                    }
+                }
+
                 this.state = CONSTANTS.STATES.OVERWORLD;
                 console.log('→ OVERWORLD');
             }
@@ -345,13 +453,10 @@ Game.prototype.updateStarterSelection = function() {
     }
 };
 
-Game.prototype.updateOverworld = function(deltaTime) {
+Game.prototype.updateOverworld = function (deltaTime) {
     // Open pause menu with Escape key (only when not moving)
     if (!this.player.isMoving && this.input.isKeyJustPressed('Escape')) {
-        this.state = CONSTANTS.STATES.MENU;
-        this.menuSelection = 0;
-        this.bagMode = null;  // Don't auto-open BAG - require Enter
-        this.shopMode = null;  // Ensure shop is also closed
+        this.setState(CONSTANTS.STATES.MENU);
         console.log('→ MENU');
         return;
     }
@@ -398,7 +503,7 @@ Game.prototype.updateOverworld = function(deltaTime) {
 
 };
 
-Game.prototype.checkNPCInteraction = function() {
+Game.prototype.checkNPCInteraction = function () {
     if (!this.currentMap.npcs || this.currentMap.npcs.length === 0) return;
 
     // Calculate tile player is facing
@@ -426,18 +531,29 @@ Game.prototype.checkNPCInteraction = function() {
     if (npc) {
         // Start trainer battle if applicable
         if ((npc.type === 'trainer' || npc.type === 'gym_leader') && npc.canBattle && !npc.defeated) {
-            this.startTrainerBattle(npc);
+            // Show dialogue first, then start battle
+            if (npc.dialogue && npc.dialogue.length > 0) {
+                this.state = CONSTANTS.STATES.DIALOGUE;
+                this.dialogueBox.show(npc.dialogue, () => {
+                    this.startTrainerBattle(npc);
+                });
+            } else {
+                this.startTrainerBattle(npc);
+            }
         } else {
             // Show dialogue for defeated trainers or non-battle NPCs
             const dialogue = npc.defeated && npc.defeatDialogue ? npc.defeatDialogue : npc.dialogue;
             if (dialogue && dialogue.length > 0) {
-                console.log(`${npc.name}: ${dialogue[0].text}`);
+                this.state = CONSTANTS.STATES.DIALOGUE;
+                this.dialogueBox.show(dialogue, () => {
+                    this.state = CONSTANTS.STATES.OVERWORLD;
+                });
             }
         }
     }
 };
 
-Game.prototype.startTrainerBattle = function(npc) {
+Game.prototype.startTrainerBattle = function (npc) {
     if (this.player.party.length === 0) {
         console.warn('Cannot start trainer battle - no trains in party');
         return;
@@ -445,19 +561,14 @@ Game.prototype.startTrainerBattle = function(npc) {
 
     console.log(`Starting trainer battle with ${npc.name}...`);
 
-    // Show dialogue first (for now just log it, could use DialogueBox later)
-    if (npc.dialogue && npc.dialogue.length > 0) {
-        console.log(`${npc.dialogue[0].text}`);
-    }
-
-    // Generate enemy trains from NPC party data
+    // Generate enemy trains from NPC party data. Train(speciesId, level) takes
+    // a numeric species id and looks it up in TRAIN_SPECIES itself.
     const enemyTrains = npc.party.map(data => {
-        const species = TRAIN_DATA.find(t => t.id === data.speciesId);
-        if (!species) {
+        if (!TRAIN_SPECIES[data.speciesId]) {
             console.error(`Species not found: ${data.speciesId}`);
             return null;
         }
-        return new Train(species, data.level);
+        return new Train(data.speciesId, data.level);
     }).filter(t => t !== null);
 
     if (enemyTrains.length === 0) {
@@ -466,7 +577,7 @@ Game.prototype.startTrainerBattle = function(npc) {
     }
 
     // Create trainer battle
-    this.battle = new Battle(this.player.party, enemyTrains, false, npc);
+    this.battle = new Battle(this, this.player.party, enemyTrains, false, npc);
 
     // Set up victory callback for defeat tracking and badges
     const originalOnVictory = this.battle.onVictory;
@@ -493,7 +604,7 @@ Game.prototype.startTrainerBattle = function(npc) {
     console.log('→ BATTLE (Trainer)');
 };
 
-Game.prototype.checkWarpTransition = function() {
+Game.prototype.checkWarpTransition = function () {
     // Only works with new world-maps system
     if (!this.currentMap.warps) return;
 
@@ -525,7 +636,7 @@ Game.prototype.checkWarpTransition = function() {
     }
 };
 
-Game.prototype.findWarp = function(map, x, y) {
+Game.prototype.findWarp = function (map, x, y) {
     if (!map.warps) return null;
 
     for (const w of map.warps) {
@@ -537,7 +648,7 @@ Game.prototype.findWarp = function(map, x, y) {
     return null;
 };
 
-Game.prototype.startBattle = function(wildTrain, isTrainerBattle = false) {
+Game.prototype.startBattle = function (wildTrain, isTrainerBattle = false) {
     if (this.player.party.length === 0) {
         console.warn('Cannot start battle - no trains in party');
         return;
@@ -546,16 +657,16 @@ Game.prototype.startBattle = function(wildTrain, isTrainerBattle = false) {
     // Battle constructor expects: (playerTrains[], enemyTrains[], isWild, trainerNPC)
     if (isTrainerBattle) {
         // Trainer battle (not yet implemented)
-        this.battle = new Battle(this.player.party, [wildTrain], false, null);
+        this.battle = new Battle(this, this.player.party, [wildTrain], false, null);
     } else {
         // Wild encounter
-        this.battle = new Battle(this.player.party, [wildTrain], true);
+        this.battle = new Battle(this, this.player.party, [wildTrain], true);
     }
     this.state = CONSTANTS.STATES.BATTLE;
     console.log('→ BATTLE');
 };
 
-Game.prototype.updateBattle = function(deltaTime) {
+Game.prototype.updateBattle = function (deltaTime) {
     if (!this.battle) {
         this.state = CONSTANTS.STATES.OVERWORLD;
         return;
@@ -585,10 +696,20 @@ Game.prototype.updateBattle = function(deltaTime) {
         if (this.battle.state === CONSTANTS.BATTLE_STATES.DEFEAT) {
             this.handleDefeat();
         } else if (this.battle.state === CONSTANTS.BATTLE_STATES.VICTORY) {
-            // Award money from battle
+            // Award money from battle (funnelled through the single accessor).
             if (this.battle.moneyEarned) {
-                this.player.money += this.battle.moneyEarned;
+                this.player.addMoney(this.battle.moneyEarned);
                 console.log(`Earned $${this.battle.moneyEarned}! Total: $${this.player.money}`);
+            }
+            // A wild train was captured this battle: add it to the party (or
+            // note that the party was full). Previously caughtTrain was set but
+            // never read, so captured trains silently vanished.
+            if (this.battle.caughtTrain) {
+                const added = this.player.addTrain(this.battle.caughtTrain);
+                this.caughtTrainResult = { name: this.battle.caughtTrain.species.name, added };
+                console.log(added ? 'Caught train added to party' : 'Party full - caught train not added');
+            } else {
+                this.caughtTrainResult = null;
             }
             this.state = CONSTANTS.STATES.BATTLE_SUMMARY;
         } else {
@@ -599,7 +720,7 @@ Game.prototype.updateBattle = function(deltaTime) {
     }
 };
 
-Game.prototype.updateBattleSummary = function() {
+Game.prototype.updateBattleSummary = function () {
     if (this.input.isKeyJustPressed('Enter') || this.input.isKeyJustPressed('z') || this.input.isVirtualKeyJustPressed('a')) {
         this.battle = null;
         this.state = CONSTANTS.STATES.OVERWORLD;
@@ -608,7 +729,7 @@ Game.prototype.updateBattleSummary = function() {
 };
 
 
-Game.prototype.renderBattleSummary = function(ctx) {
+Game.prototype.renderBattleSummary = function (ctx) {
     if (!this.battle) return;
 
     // Render the battle behind the summary
@@ -638,35 +759,48 @@ Game.prototype.renderBattleSummary = function(ctx) {
 
     if (this.battle.moneyEarned) {
         ctx.font = '20px monospace';
-        ctx.fillText(`You earned $${this.battle.moneyEarned}!`, this.canvas.width / 2, boxY + 100);
+        ctx.fillText(`You earned $${this.battle.moneyEarned}!`, this.canvas.width / 2, boxY + 95);
+    }
+
+    if (this.caughtTrainResult) {
+        ctx.font = '16px monospace';
+        const msg = this.caughtTrainResult.added
+            ? `Caught ${this.caughtTrainResult.name}!`
+            : `Party full! ${this.caughtTrainResult.name} got away.`;
+        ctx.fillText(msg, this.canvas.width / 2, boxY + 140);
     }
 
     ctx.textAlign = 'left'; // Reset text align
 };
 
-Game.prototype.handleDefeat = function() {
+Game.prototype.handleDefeat = function () {
     console.log('Player defeated - triggering blackout');
 
-    // Heal all trains to full HP
+    // Heal all trains to full HP (and clear status).
     this.player.healParty();
 
-    // Reduce money by 50% (or set to 0 if less than 100)
-    if (this.player.money < 100) {
-        this.player.money = 0;
-    } else {
-        this.player.money = Math.floor(this.player.money * 0.5);
-    }
+    // Lose half your money on blackout.
+    this.player.money = this.player.money < 100 ? 0 : Math.floor(this.player.money * 0.5);
 
-    // Teleport player back to Piston Town (default healing depot spawn point)
+    // Teleport back to the Piston Town spawn. The map key MUST match the key
+    // maps are registered under ('PistonTown'), and we must reassign the live
+    // currentMap object - not just the player's map-id string.
+    const respawnKey = this.maps['PistonTown'] ? 'PistonTown' : 'pallet_town';
+    this.currentMap = this.maps[respawnKey];
+    this.player.currentMap = respawnKey;
     this.player.x = 10;
     this.player.y = 7;
-    this.player.currentMap = 'piston_town';
+    this.player.targetX = 10;
+    this.player.targetY = 7;
+    this.player.isMoving = false;
     this.player.direction = CONSTANTS.DIRECTIONS.DOWN;
 
-    console.log(`Blackout - Money reduced to ${this.player.money}, teleported to Piston Town`);
+    this.battle = null;
+    this.state = CONSTANTS.STATES.OVERWORLD;
+    console.log(`Blackout - money now ${this.player.money}, respawned at ${respawnKey}`);
 };
 
-Game.prototype.render = function() {
+Game.prototype.render = function () {
     const ctx = this.ctx;
 
     // Clear screen
@@ -704,40 +838,125 @@ Game.prototype.render = function() {
     }
 };
 
-Game.prototype.renderLoading = function(ctx) {
-    ctx.fillStyle = CONSTANTS.COLORS.WHITE;
+Game.prototype.renderLoading = function (ctx) {
+    const w = this.canvas.width, h = this.canvas.height;
+    const C = CONSTANTS.COLORS;
+    ctx.fillStyle = C.UI_BG;
+    ctx.fillRect(0, 0, w, h);
+
+    ctx.textAlign = 'center';
+    ctx.fillStyle = C.LOCO_BODY;
     ctx.font = '24px monospace';
-    ctx.fillText('Loading...', 300, 280);
+    ctx.fillText('NOW LOADING', w / 2, h / 2 - 50);
 
-    // Progress bar
-    const barWidth = 400;
-    const barHeight = 30;
-    const barX = (this.canvas.width - barWidth) / 2;
-    const barY = 320;
+    const barWidth = 400, barHeight = 26;
+    const barX = (w - barWidth) / 2, barY = h / 2 - 10;
+    ctx.fillStyle = '#181818';
+    this.roundRect(ctx, barX - 4, barY - 4, barWidth + 8, barHeight + 8, 8); ctx.fill();
+    ctx.fillStyle = C.HP_BG;
+    this.roundRect(ctx, barX, barY, barWidth, barHeight, 6); ctx.fill();
+    ctx.fillStyle = C.LOCO_BRASS;
+    const fillW = Math.max(0, (barWidth) * this.loadingProgress);
+    if (fillW > 0) { this.roundRect(ctx, barX, barY, fillW, barHeight, 6); ctx.fill(); }
 
-    // Border
-    ctx.strokeStyle = CONSTANTS.COLORS.WHITE;
-    ctx.strokeRect(barX, barY, barWidth, barHeight);
-
-    // Fill
-    ctx.fillStyle = CONSTANTS.COLORS.UI_HIGHLIGHT;
-    ctx.fillRect(barX + 2, barY + 2, (barWidth - 4) * this.loadingProgress, barHeight - 4);
-
+    ctx.fillStyle = C.DARK;
     ctx.font = '16px monospace';
-    const percent = Math.floor(this.loadingProgress * 100);
-    ctx.fillStyle = CONSTANTS.COLORS.WHITE;
-    ctx.fillText(`${percent}%`, 360, 370);
+    ctx.fillText(`${Math.floor(this.loadingProgress * 100)}%`, w / 2, barY + 60);
+    ctx.textAlign = 'left';
 };
 
-Game.prototype.renderTitle = function(ctx) {
-    ctx.fillStyle = CONSTANTS.COLORS.WHITE;
-    ctx.font = '32px monospace';
-    ctx.fillText('TRAIN BATTLE RPG', 150, 200);
-    ctx.font = '16px monospace';
-    ctx.fillText('Press ENTER to start', 250, 300);
+Game.prototype.renderTitle = function (ctx) {
+    const w = this.canvas.width, h = this.canvas.height;
+    const C = CONSTANTS.COLORS;
+
+    // Sky gradient backdrop
+    const sky = ctx.createLinearGradient(0, 0, 0, h);
+    sky.addColorStop(0, C.BATTLE_SKY2);
+    sky.addColorStop(1, C.BATTLE_SKY);
+    ctx.fillStyle = sky;
+    ctx.fillRect(0, 0, w, h);
+
+    // Rolling hills
+    ctx.fillStyle = C.GRASS_ALT;
+    ctx.beginPath();
+    ctx.moveTo(0, h * 0.7);
+    ctx.quadraticCurveTo(w * 0.3, h * 0.6, w * 0.6, h * 0.72);
+    ctx.quadraticCurveTo(w * 0.85, h * 0.8, w, h * 0.68);
+    ctx.lineTo(w, h); ctx.lineTo(0, h); ctx.closePath(); ctx.fill();
+
+    // A little locomotive riding the hill
+    this.drawTitleTrain(ctx, w * 0.5 - 80, h * 0.55, 2.2);
+
+    // Title logo plate
+    const tx = w / 2;
+    ctx.fillStyle = '#181818';
+    this.roundRect(ctx, tx - 250, 70, 500, 120, 16); ctx.fill();
+    ctx.fillStyle = C.UI_BG;
+    this.roundRect(ctx, tx - 242, 78, 484, 104, 12); ctx.fill();
+
+    ctx.textAlign = 'center';
+    ctx.fillStyle = C.LOCO_RED;
+    ctx.font = 'bold 42px monospace';
+    ctx.fillText('TRAIN BATTLE', tx + 3, 128);
+    ctx.fillStyle = C.LOCO_BRASS;
+    ctx.fillText('TRAIN BATTLE', tx, 125);
+    ctx.fillStyle = '#181818';
+    ctx.font = 'bold 30px monospace';
+    ctx.fillText('R P G', tx, 168);
+
+    // Blinking prompt
+    if (Math.floor(this.animClock * 2) % 2 === 0) {
+        ctx.fillStyle = '#181818';
+        ctx.font = '20px monospace';
+        ctx.fillText('PRESS ENTER', tx, h - 90);
+    }
+    ctx.font = '12px monospace';
+    ctx.fillStyle = C.DARK;
+    ctx.fillText('` or F1 for debug menu', tx, h - 50);
+    ctx.textAlign = 'left';
 };
 
-Game.prototype.renderDebugMenu = function(ctx) {
+// Rounded-rect path helper (uses native roundRect where available).
+Game.prototype.roundRect = function (ctx, x, y, w, h, r) {
+    ctx.beginPath();
+    if (ctx.roundRect) { ctx.roundRect(x, y, w, h, r); return; }
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y, x + w, y + h, r);
+    ctx.arcTo(x + w, y + h, x, y + h, r);
+    ctx.arcTo(x, y + h, x, y, r);
+    ctx.arcTo(x, y, x + w, y, r);
+    ctx.closePath();
+};
+
+// Decorative locomotive for the title screen.
+Game.prototype.drawTitleTrain = function (ctx, x, y, s) {
+    const C = CONSTANTS.COLORS;
+    ctx.fillStyle = C.LOCO_BODY;
+    ctx.fillRect(x, y, 70 * s, 22 * s);            // boiler
+    ctx.fillStyle = C.LOCO_BODY_DARK;
+    ctx.fillRect(x + 50 * s, y - 14 * s, 20 * s, 16 * s); // cab
+    ctx.fillStyle = C.LOCO_IRON_DARK;
+    ctx.fillRect(x - 4 * s, y - 4 * s, 8 * s, 30 * s);   // front buffer
+    ctx.fillStyle = C.LOCO_BRASS;
+    ctx.fillRect(x + 10 * s, y - 12 * s, 7 * s, 12 * s); // smokestack
+    // wheels
+    ctx.fillStyle = C.LOCO_IRON;
+    for (let i = 0; i < 3; i++) {
+        ctx.beginPath();
+        ctx.arc(x + (12 + i * 22) * s, y + 22 * s, 7 * s, 0, Math.PI * 2);
+        ctx.fill();
+    }
+    // steam puffs
+    ctx.fillStyle = 'rgba(232,232,232,0.9)';
+    for (let i = 0; i < 3; i++) {
+        const px = x + (13 * s) + Math.sin(this.animClock + i) * 6 - i * 10 * s;
+        ctx.beginPath();
+        ctx.arc(px, y - (22 + i * 10) * s, (4 + i * 2) * s, 0, Math.PI * 2);
+        ctx.fill();
+    }
+};
+
+Game.prototype.renderDebugMenu = function (ctx) {
     ctx.fillStyle = CONSTANTS.COLORS.WHITE;
     ctx.font = '28px monospace';
     ctx.fillText('DEBUG MENU', 260, 80);
@@ -767,7 +986,7 @@ Game.prototype.renderDebugMenu = function(ctx) {
     });
 };
 
-Game.prototype.wrapText = function(ctx, text, x, y, maxWidth, lineHeight) {
+Game.prototype.wrapText = function (ctx, text, x, y, maxWidth, lineHeight) {
     const words = text.split(' ');
     let line = '';
     let currentY = y;
@@ -785,7 +1004,7 @@ Game.prototype.wrapText = function(ctx, text, x, y, maxWidth, lineHeight) {
     ctx.fillText(line, x, currentY);
 };
 
-Game.prototype.renderIntro = function(ctx) {
+Game.prototype.renderIntro = function (ctx) {
     if (!this.introScene) return;
 
     const dialogue = this.introScene.getCurrentDialogue();
@@ -805,10 +1024,11 @@ Game.prototype.renderIntro = function(ctx) {
     }
 };
 
-Game.prototype.renderStarterSelection = function(ctx) {
+Game.prototype.renderStarterSelection = function (ctx) {
     if (!this.starterSelection) return;
 
     const ss = this.starterSelection;
+
     ctx.fillStyle = CONSTANTS.COLORS.WHITE;
     ctx.font = '16px monospace';
 
@@ -862,8 +1082,15 @@ Game.prototype.renderStarterSelection = function(ctx) {
     }
 };
 
-Game.prototype.renderOverworld = function(ctx) {
-    if (!this.currentMap) return;
+Game.prototype.renderOverworld = function (ctx) {
+    if (!this.currentMap) {
+        // Only log once to avoid spam
+        if (!this._loggedMapError) {
+            console.error('❌ renderOverworld: currentMap is null!');
+            this._loggedMapError = true;
+        }
+        return;
+    }
 
     const tileSize = CONSTANTS.TILE_SIZE * CONSTANTS.SCALE;
     const canvas = ctx.canvas;
@@ -895,28 +1122,17 @@ Game.prototype.renderOverworld = function(ctx) {
             }
         }
     } else {
-                    // Fallback to colored rectangles if no tileset is loaded
-                for (let y = startTileY; y < endTileY; y++) {
-                    for (let x = startTileX; x < endTileX; x++) {
-                        const tile = this.currentMap.getTile(x, y);
-                        const color = this.getTileColor(tile);
-                        const screenX = (x * tileSize) - clampedCameraX;
-                        const screenY = (y * tileSize) - clampedCameraY;
-                        
-                        this.ctx.fillStyle = color;
-                        this.ctx.fillRect(
-                            screenX,
-                            screenY,
-                            tileSize,
-                            tileSize
-                        );
-        
-                        // Draw grid outline
-                        this.ctx.strokeStyle = 'rgba(0, 0, 0, 0.2)';
-                        this.ctx.strokeRect(screenX, screenY, tileSize, tileSize);
-                    }
-                }
+        // Textured fallback tiles (no tileset loaded). No more flat rects with
+        // a harsh grid outline - drawFallbackTile gives each material a surface.
+        for (let y = startTileY; y < endTileY; y++) {
+            for (let x = startTileX; x < endTileX; x++) {
+                const tile = this.currentMap.getTile(x, y);
+                const screenX = (x * tileSize) - clampedCameraX;
+                const screenY = (y * tileSize) - clampedCameraY;
+                this.drawFallbackTile(ctx, tile, screenX, screenY, tileSize, x, y);
             }
+        }
+    }
     // Draw NPCs
     if (this.currentMap.npcs && this.currentMap.npcs.length > 0) {
         for (const npc of this.currentMap.npcs) {
@@ -927,18 +1143,13 @@ Game.prototype.renderOverworld = function(ctx) {
             if (npcScreenX >= -tileSize && npcScreenX < canvas.width &&
                 npcScreenY >= -tileSize && npcScreenY < canvas.height) {
 
-                // Color based on type and defeated status
-                if (npc.defeated) {
-                    ctx.fillStyle = '#888888'; // Gray for defeated trainers
-                } else if (npc.type === 'gym_leader') {
-                    ctx.fillStyle = '#FFD700'; // Gold for gym leaders
-                } else if (npc.type === 'trainer') {
-                    ctx.fillStyle = '#FF6600'; // Orange for trainers
-                } else {
-                    ctx.fillStyle = '#FFFF00'; // Yellow for NPCs
-                }
-
-                ctx.fillRect(npcScreenX, npcScreenY, tileSize, tileSize);
+                // Tint per role/defeated; draw as a little person, not a square.
+                let shirt;
+                if (npc.defeated) shirt = '#8A8A8A';
+                else if (npc.type === 'gym_leader') shirt = CONSTANTS.COLORS.LOCO_BRASS;
+                else if (npc.type === 'trainer') shirt = '#D64545';
+                else shirt = '#5878A8';
+                this.drawCharacter(ctx, npcScreenX, npcScreenY, tileSize, shirt, CONSTANTS.DIRECTIONS.DOWN);
             }
         }
     }
@@ -951,104 +1162,205 @@ Game.prototype.renderOverworld = function(ctx) {
     // For now, draw a Pokemon-style trainer representation
     this.drawPlayer(ctx, playerScreenX, playerScreenY, tileSize, this.player.direction);
 
-    // Debug info
-    ctx.fillStyle = CONSTANTS.COLORS.WHITE;
-    ctx.font = '12px monospace';
-    ctx.fillText(`Map: ${this.currentMap.id || this.currentMap.name}`, 10, 20);
-    ctx.fillText(`Pos: (${this.player.x}, ${this.player.y})`, 10, 35);
-};
-
-Game.prototype.getTileColor = function(tile) {
-    const colors = {
-        0: '#000000', // void/wall
-        1: '#00AA00', // grass
-        2: '#00FF00', // tall grass
-        3: '#CCAA88', // path
-        4: '#0066FF', // water
-        5: '#666666', // wall
-        6: '#888888', // rails
-        12: '#8B4513' // door
-    };
-    return colors[tile] || '#FF00FF';
-};
-
-// Draw player character (interim solution until proper sprite is generated)
-Game.prototype.drawPlayer = function(ctx, x, y, size, direction) {
-    const centerX = x + size / 2;
-    const centerY = y + size / 2;
-    const radius = size * 0.35;
-
-    // Body (Pokemon trainer style - simple circle/oval)
-    ctx.fillStyle = CONSTANTS.COLORS.UI_HIGHLIGHT; // Blue shirt
-    ctx.beginPath();
-    ctx.ellipse(centerX, centerY + size * 0.1, radius * 0.9, radius * 1.1, 0, 0, Math.PI * 2);
-    ctx.fill();
-
-    // Head
-    ctx.fillStyle = CONSTANTS.COLORS.LIGHT; // Skin tone
-    ctx.beginPath();
-    ctx.arc(centerX, centerY - size * 0.15, radius * 0.6, 0, Math.PI * 2);
-    ctx.fill();
-
-    // Hat (Pokemon trainer style)
-    ctx.fillStyle = CONSTANTS.COLORS.HP_RED;
-    ctx.beginPath();
-    ctx.arc(centerX, centerY - size * 0.15, radius * 0.65, Math.PI, Math.PI * 2);
-    ctx.fill();
-
-    // Direction indicator (simple arrow/facing)
-    ctx.fillStyle = CONSTANTS.COLORS.BLACK;
-    ctx.beginPath();
-    switch (direction) {
-        case CONSTANTS.DIRECTIONS.UP:
-            ctx.moveTo(centerX, centerY - size * 0.35);
-            ctx.lineTo(centerX - size * 0.1, centerY - size * 0.2);
-            ctx.lineTo(centerX + size * 0.1, centerY - size * 0.2);
-            break;
-        case CONSTANTS.DIRECTIONS.DOWN:
-            ctx.moveTo(centerX, centerY + size * 0.4);
-            ctx.lineTo(centerX - size * 0.1, centerY + size * 0.25);
-            ctx.lineTo(centerX + size * 0.1, centerY + size * 0.25);
-            break;
-        case CONSTANTS.DIRECTIONS.LEFT:
-            ctx.moveTo(centerX - size * 0.35, centerY);
-            ctx.lineTo(centerX - size * 0.2, centerY - size * 0.1);
-            ctx.lineTo(centerX - size * 0.2, centerY + size * 0.1);
-            break;
-        case CONSTANTS.DIRECTIONS.RIGHT:
-            ctx.moveTo(centerX + size * 0.35, centerY);
-            ctx.lineTo(centerX + size * 0.2, centerY - size * 0.1);
-            ctx.lineTo(centerX + size * 0.2, centerY + size * 0.1);
-            break;
+    // Developer overlay - off by default (was always-on, cluttering the view).
+    if (this.debug) {
+        ctx.fillStyle = 'rgba(0,0,0,0.55)';
+        ctx.fillRect(6, 6, 190, 38);
+        ctx.fillStyle = CONSTANTS.COLORS.WHITE;
+        ctx.font = '12px monospace';
+        ctx.fillText(`Map: ${this.currentMap.id || this.currentMap.name}`, 12, 22);
+        ctx.fillText(`Pos: (${this.player.x}, ${this.player.y})`, 12, 37);
     }
-    ctx.fill();
+
+    // Render dialogue box if active
+    if (this.state === CONSTANTS.STATES.DIALOGUE && this.dialogueBox.isActive()) {
+        const dialogue = this.dialogueBox.getCurrentDialogue();
+        if (dialogue) {
+            // Draw box at bottom
+            const boxHeight = 100;
+            const boxY = canvas.height - boxHeight - 10;
+            UI.drawTextBox(ctx, 10, boxY, canvas.width - 20, boxHeight, dialogue.text);
+
+            // Draw speaker name
+            if (dialogue.speaker) {
+                ctx.fillStyle = CONSTANTS.COLORS.UI_HIGHLIGHT;
+                ctx.fillRect(20, boxY - 15, ctx.measureText(dialogue.speaker).width + 20, 25);
+                ctx.fillStyle = CONSTANTS.COLORS.WHITE;
+                ctx.font = 'bold 16px monospace';
+                ctx.fillText(dialogue.speaker, 30, boxY + 2);
+            }
+        }
+    }
 };
 
-Game.prototype.renderBattle = function(ctx) {
+// Hoisted out of getTileColor so the literal isn't rebuilt on every tile,
+// every frame (the fallback path draws hundreds of tiles per frame).
+// Muted GBC palette - the old pure #00FF00 grass read as eye-searing.
+Game.TILE_COLORS = {
+    0: '#3A3A3A', // void/wall
+    1: '#7BB662', // grass
+    2: '#4F9A4B', // tall grass
+    3: '#D8C7A0', // path
+    4: '#5878A8', // water
+    5: '#6B4226', // wall
+    6: '#5C5C5C', // rails
+    12: '#8B5A3C' // door
+};
+
+Game.prototype.getTileColor = function (tile) {
+    return Game.TILE_COLORS[tile] || '#7BB662';
+};
+
+// Draw a single textured fallback tile. Two-tone + deterministic speckle keyed
+// on tile coords so grass/path/water read as a surface, not a flat fill.
+Game.prototype.drawFallbackTile = function (ctx, tile, sx, sy, size, tx, ty) {
+    const C = CONSTANTS.COLORS;
+    const even = ((tx + ty) & 1) === 0;
+    // Deterministic pseudo-noise per tile (no Math.random -> stable frames).
+    const h = ((tx * 73856093) ^ (ty * 19349663)) >>> 0;
+
+    if (tile === 1) { // grass
+        ctx.fillStyle = even ? C.GRASS_BASE : C.GRASS_ALT;
+        ctx.fillRect(sx, sy, size, size);
+        ctx.fillStyle = C.GRASS_SPECK;
+        // a few short blades, placed deterministically
+        for (let i = 0; i < 3; i++) {
+            const bx = sx + ((h >> (i * 3)) % (size - 4)) + 2;
+            const by = sy + ((h >> (i * 3 + 8)) % (size - 6)) + 4;
+            ctx.fillRect(bx, by, 2, 4);
+        }
+    } else if (tile === 2) { // tall grass
+        ctx.fillStyle = even ? C.TALLGRASS_BASE : C.TALLGRASS_ALT;
+        ctx.fillRect(sx, sy, size, size);
+        ctx.fillStyle = C.GRASS_BASE;
+        for (let i = 0; i < 4; i++) {
+            const bx = sx + 3 + i * (size / 4);
+            ctx.fillRect(bx, sy + size - 10, 3, 8);
+        }
+    } else if (tile === 3 || tile === 12) { // path / door
+        ctx.fillStyle = tile === 12 ? C.DOOR_BASE : C.PATH_BASE;
+        ctx.fillRect(sx, sy, size, size);
+        ctx.fillStyle = tile === 12 ? C.WALL_ALT : C.PATH_ALT;
+        // subtle paving speckle
+        ctx.fillRect(sx + (h % (size - 3)), sy + ((h >> 5) % (size - 3)), 2, 2);
+        if (tile === 12) { // doorway frame
+            ctx.fillStyle = C.LOCO_BRASS;
+            ctx.fillRect(sx + size * 0.3, sy + size * 0.15, size * 0.4, size * 0.7);
+        }
+    } else if (tile === 4) { // water
+        ctx.fillStyle = C.WATER_BASE;
+        ctx.fillRect(sx, sy, size, size);
+        ctx.fillStyle = C.WATER_ALT;
+        const wob = Math.sin((this.animClock * 2) + tx + ty) > 0 ? 0 : 3;
+        ctx.fillRect(sx + 3 + wob, sy + size * 0.4, size * 0.4, 2);
+        ctx.fillRect(sx + size * 0.5 - wob, sy + size * 0.7, size * 0.3, 2);
+    } else if (tile === 6) { // rails
+        ctx.fillStyle = C.PATH_ALT;
+        ctx.fillRect(sx, sy, size, size);
+        ctx.fillStyle = C.RAIL_TIE;
+        for (let i = 0; i < 3; i++) ctx.fillRect(sx + 2, sy + 3 + i * (size / 3), size - 4, 3);
+        ctx.fillStyle = C.RAIL_BASE;
+        ctx.fillRect(sx + size * 0.28, sy, 3, size);
+        ctx.fillRect(sx + size * 0.62, sy, 3, size);
+    } else { // 0 = wall / void and anything else
+        ctx.fillStyle = even ? C.WALL_BASE : C.WALL_ALT;
+        ctx.fillRect(sx, sy, size, size);
+        ctx.fillStyle = 'rgba(0,0,0,0.18)';
+        ctx.fillRect(sx, sy + size - 4, size, 4); // bottom shadow for depth
+    }
+};
+
+// Player uses the shared character drawer with a red cap (Pokemon-protagonist
+// vibe). Kept as its own method so existing call sites don't change.
+Game.prototype.drawPlayer = function (ctx, x, y, size, direction) {
+    this.drawCharacter(ctx, x, y, size, '#3A6BB0', direction, true);
+};
+
+// A small top-down trainer sprite drawn from blocks: ground shadow, legs,
+// torso (shirt color), head with skin tone, and a cap whose brim shows the
+// facing direction. Used for both the player and NPCs.
+Game.prototype.drawCharacter = function (ctx, x, y, size, shirt, direction, isPlayer) {
+    const cx = x + size / 2;
+    const u = size / 16; // pixel unit on a 16-grid
+    const skin = '#F0C8A0';
+    const cap = isPlayer ? '#D64545' : '#2C2C3A';
+    const hair = '#3A2A1A';
+
+    // soft contact shadow
+    ctx.fillStyle = 'rgba(0,0,0,0.22)';
+    ctx.beginPath();
+    ctx.ellipse(cx, y + size - 2 * u, 5 * u, 2 * u, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // legs
+    ctx.fillStyle = '#3A3A4A';
+    ctx.fillRect(cx - 3 * u, y + 11 * u, 2.5 * u, 4 * u);
+    ctx.fillRect(cx + 0.5 * u, y + 11 * u, 2.5 * u, 4 * u);
+
+    // torso
+    ctx.fillStyle = shirt;
+    ctx.fillRect(cx - 4 * u, y + 7 * u, 8 * u, 5 * u);
+    // arms
+    ctx.fillStyle = shirt;
+    ctx.fillRect(cx - 5 * u, y + 7 * u, 1.5 * u, 4 * u);
+    ctx.fillRect(cx + 3.5 * u, y + 7 * u, 1.5 * u, 4 * u);
+
+    // head
+    ctx.fillStyle = skin;
+    ctx.fillRect(cx - 3.5 * u, y + 2 * u, 7 * u, 5 * u);
+
+    // hair/cap base
+    ctx.fillStyle = cap;
+    ctx.fillRect(cx - 4 * u, y + 1 * u, 8 * u, 2.5 * u);
+    // cap brim points in the facing direction
+    ctx.fillStyle = cap;
+    switch (direction) {
+        case CONSTANTS.DIRECTIONS.DOWN:
+            ctx.fillRect(cx - 3 * u, y + 3 * u, 6 * u, 1.2 * u); break;
+        case CONSTANTS.DIRECTIONS.UP:
+            ctx.fillStyle = hair; ctx.fillRect(cx - 3.5 * u, y + 3 * u, 7 * u, 2 * u); break;
+        case CONSTANTS.DIRECTIONS.LEFT:
+            ctx.fillRect(cx - 5 * u, y + 2.5 * u, 2 * u, 1.5 * u); break;
+        case CONSTANTS.DIRECTIONS.RIGHT:
+            ctx.fillRect(cx + 3 * u, y + 2.5 * u, 2 * u, 1.5 * u); break;
+    }
+
+    // eyes (only when facing toward/side the camera)
+    if (direction !== CONSTANTS.DIRECTIONS.UP) {
+        ctx.fillStyle = '#1A1208';
+        if (direction === CONSTANTS.DIRECTIONS.LEFT) {
+            ctx.fillRect(cx - 2.5 * u, y + 4.5 * u, 1.2 * u, 1.2 * u);
+        } else if (direction === CONSTANTS.DIRECTIONS.RIGHT) {
+            ctx.fillRect(cx + 1.3 * u, y + 4.5 * u, 1.2 * u, 1.2 * u);
+        } else {
+            ctx.fillRect(cx - 2.5 * u, y + 4.5 * u, 1.2 * u, 1.2 * u);
+            ctx.fillRect(cx + 1.3 * u, y + 4.5 * u, 1.2 * u, 1.2 * u);
+        }
+    }
+};
+
+Game.prototype.renderBattle = function (ctx) {
     if (this.battle && this.battle.render) {
         this.battle.render(ctx);
     }
 };
 
 // Save/Load system
-Game.prototype.save = function() {
+//
+// Serialization is owned by Player.toJSON/fromJSON (single source of truth) so
+// badges, story flags, and IVs can never be silently dropped by a divergent
+// hand-rolled schema. The transient `state` is deliberately NOT persisted -
+// the title screen decides whether to resume (see updateTitle).
+Game.prototype.SAVE_KEY = 'trainBattleRPG_save';
+
+Game.prototype.save = function () {
     try {
         const saveData = {
-            player: {
-                name: this.player.name,
-                x: this.player.x,
-                y: this.player.y,
-                direction: this.player.direction,
-                currentMap: this.player.currentMap,
-                money: this.player.money,
-                party: this.player.party.map(t => t.toJSON ? t.toJSON() : t),
-                items: this.player.items,
-                hasStarterTrain: this.player.hasStarterTrain
-            },
-            state: this.state
+            version: Player.SAVE_VERSION,
+            player: this.player.toJSON(),
+            savedAt: Date.now()
         };
-
-        localStorage.setItem('trainBattleRPG_save', JSON.stringify(saveData));
+        localStorage.setItem(this.SAVE_KEY, JSON.stringify(saveData));
         console.log('💾 Game saved');
         return true;
     } catch (err) {
@@ -1057,34 +1369,26 @@ Game.prototype.save = function() {
     }
 };
 
-Game.prototype.load = function() {
+Game.prototype.load = function () {
     try {
-        const saved = localStorage.getItem('trainBattleRPG_save');
+        const saved = localStorage.getItem(this.SAVE_KEY);
         if (!saved) return false;
 
         const data = JSON.parse(saved);
+        if (!data || !data.player) return false;
 
-        // Restore player state
-        this.player.name = data.player.name;
-        this.player.x = data.player.x;
-        this.player.y = data.player.y;
-        this.player.direction = data.player.direction;
-        this.player.currentMap = data.player.currentMap;
-        this.player.money = data.player.money;
-        this.player.items = data.player.items;
-        this.player.hasStarterTrain = data.player.hasStarterTrain;
+        this.player = Player.fromJSON(data.player);
 
-        // Restore party
-        this.player.party = data.player.party.map(t => Train.fromJSON ? Train.fromJSON(t) : new Train(t.species, t.level));
-
-        // Restore map
+        // Resolve the live map object from the saved map-id key, falling back
+        // to the start town if the key is stale/unknown.
         if (this.maps[this.player.currentMap]) {
             this.currentMap = this.maps[this.player.currentMap];
+        } else if (this.maps['PistonTown']) {
+            this.currentMap = this.maps['PistonTown'];
+            this.player.currentMap = 'PistonTown';
         }
 
-        // Restore state
-        this.state = data.state;
-
+        this.loadedSave = true;
         console.log('📁 Game loaded');
         return true;
     } catch (err) {
@@ -1093,15 +1397,15 @@ Game.prototype.load = function() {
     }
 };
 
-Game.prototype.exportSaveToken = function() {
-    const saved = localStorage.getItem('trainBattleRPG_save');
+Game.prototype.exportSaveToken = function () {
+    const saved = localStorage.getItem(this.SAVE_KEY);
     return saved ? btoa(saved) : null;
 };
 
-Game.prototype.importSaveToken = function(token) {
+Game.prototype.importSaveToken = function (token) {
     try {
         const decoded = atob(token);
-        localStorage.setItem('trainBattleRPG_save', decoded);
+        localStorage.setItem(this.SAVE_KEY, decoded);
         return this.load();
     } catch (err) {
         console.error('Import failed:', err);
@@ -1111,7 +1415,7 @@ Game.prototype.importSaveToken = function(token) {
 // TEMP FILE: Menu methods to add to game.js before final line
 // Add these methods before the final closing of game.js
 
-Game.prototype.updateMenu = function() {
+Game.prototype.updateMenu = function () {
     // SHOP mode - browse and purchase items (only if shop is actually open, not just highlighted)
     if (this.menuOptions[this.menuSelection] === 'SHOP' && this.shopMode === 'active') {
         // Navigate shop items
@@ -1121,11 +1425,10 @@ Game.prototype.updateMenu = function() {
             this.shopSelection = Math.min(this.shopItems.length - 1, this.shopSelection + 1);
         }
 
-        // Purchase item
+        // Purchase item (spendMoney is the single gate; never goes negative).
         if (this.input.isKeyJustPressed('Enter') || this.input.isKeyJustPressed('z') || this.input.isVirtualKeyJustPressed('a')) {
             const item = this.shopItems[this.shopSelection];
-            if (this.player.money >= item.price) {
-                this.player.money -= item.price;
+            if (this.player.spendMoney(item.price)) {
                 this.player.items[item.name] = (this.player.items[item.name] || 0) + 1;
                 console.log(`Bought ${item.displayName} for $${item.price}! Money: $${this.player.money}`);
             } else {
@@ -1155,20 +1458,16 @@ Game.prototype.updateMenu = function() {
         // Select train to use item on
         if (this.input.isKeyJustPressed('Enter') || this.input.isKeyJustPressed('z') || this.input.isVirtualKeyJustPressed('a')) {
             const train = this.player.party[this.trainSelection];
-            const itemName = this.selectedItem;
+            const def = Items.get(this.selectedItem);
 
-            if (itemName === 'potion' && train.currentHP < train.stats.hp) {
-                train.heal(20);
-                this.player.items.potion = Math.max(0, this.player.items.potion - 1);
+            // Train has `maxHP`, NOT `stats.hp` (that property does not exist and
+            // threw here previously). Heal amount comes from the Items registry.
+            if (def && def.kind === 'heal' && train && train.currentHP < train.maxHP) {
+                train.heal(def.amount);
+                this.player.items[def.id] = Math.max(0, (this.player.items[def.id] || 0) - 1);
                 this.bagMode = 'list';
                 this.selectedItem = null;
-                console.log(`Used Potion on ${train.name}`);
-            } else if (itemName === 'super_potion' && train.currentHP < train.stats.hp) {
-                train.heal(50);
-                this.player.items.super_potion = Math.max(0, this.player.items.super_potion - 1);
-                this.bagMode = 'list';
-                this.selectedItem = null;
-                console.log(`Used Super Potion on ${train.name}`);
+                console.log(`Used ${def.name} on ${train.nickname || train.species.name}`);
             }
         }
 
@@ -1251,13 +1550,12 @@ Game.prototype.updateMenu = function() {
             this.shopSelection = 0;
             this.shopMode = 'active';
         } else if (option === 'HEAL') {
-            this.player.healAllTrains();
+            // Heal synchronously. A setTimeout here could fire after the player
+            // had already opened another menu or entered a battle, yanking them
+            // out of it mid-action.
+            this.player.healParty();
             console.log('All trains healed to full HP!');
-            // Brief visual feedback then return to overworld
-            setTimeout(() => {
-                this.state = CONSTANTS.STATES.OVERWORLD;
-                console.log('→ OVERWORLD');
-            }, 1000);
+            this.setState(CONSTANTS.STATES.OVERWORLD);
         } else if (option === 'SAVE') {
             this.save();
             console.log('Game saved!');
@@ -1274,7 +1572,7 @@ Game.prototype.updateMenu = function() {
     }
 };
 
-Game.prototype.renderMenu = function() {
+Game.prototype.renderMenu = function () {
     // Render overworld behind menu
     this.renderOverworld(this.ctx);
 

--- a/js/graphics.js
+++ b/js/graphics.js
@@ -9,8 +9,23 @@ function loadImage(src) {
   if (IMG_CACHE.has(src)) return IMG_CACHE.get(src);
   const p = new Promise((resolve, reject) => {
     const img = new Image();
-    img.onload = () => resolve(img);
-    img.onerror = reject;
+
+    const timeoutId = setTimeout(() => {
+      console.warn(`Image load timed out: ${src}`);
+      // Resolve with empty image or null to prevent blocking, or reject
+      // Resolving with the image object (even if incomplete) might be safer than rejecting if we want to continue
+      // But rejecting allows the caller to handle it.
+      reject(new Error(`Timeout loading ${src}`));
+    }, 2000);
+
+    img.onload = () => {
+      clearTimeout(timeoutId);
+      resolve(img);
+    };
+    img.onerror = (e) => {
+      clearTimeout(timeoutId);
+      reject(e);
+    };
     img.src = src;
   });
   IMG_CACHE.set(src, p);

--- a/js/input.js
+++ b/js/input.js
@@ -27,7 +27,7 @@ class InputHandler {
 
         window.addEventListener('keyup', (e) => {
             this.keys[e.key] = false;
-            this.keyJustPressed[e.key] = false;
+            // Don't clear keyJustPressed on keyup - let it be consumed by the game loop
         });
     }
 

--- a/js/items.js
+++ b/js/items.js
@@ -1,0 +1,70 @@
+/**
+ * Items registry - single source of truth for item metadata and effects.
+ *
+ * Every consumer (shop catalog, field bag, battle item menu) reads from this
+ * table instead of hardcoding prices/heal amounts/behaviour. To add an item,
+ * add one entry here.
+ *
+ * Fields:
+ *   id            - inventory key (matches Player.items keys)
+ *   name          - display name
+ *   price         - shop buy price (0 = not sold)
+ *   description   - short blurb for shop/bag UI
+ *   kind          - 'heal' | 'capture' | 'key'
+ *   amount        - for kind 'heal': HP restored
+ *   usableInField - can be used from the pause-menu bag
+ *   usableInBattle- can be used from the battle item menu
+ *   sold          - appears in the shop
+ */
+const ITEMS = {
+    potion: {
+        id: 'potion', name: 'Potion', price: 300,
+        description: 'Heals 20 HP', kind: 'heal', amount: 20,
+        usableInField: true, usableInBattle: true, sold: true
+    },
+    super_potion: {
+        id: 'super_potion', name: 'Super Potion', price: 700,
+        description: 'Heals 50 HP', kind: 'heal', amount: 50,
+        usableInField: true, usableInBattle: true, sold: true
+    },
+    boxcar: {
+        id: 'boxcar', name: 'Boxcar', price: 200,
+        description: 'Catches wild trains', kind: 'capture',
+        usableInField: false, usableInBattle: true, sold: true
+    },
+    train_ticket: {
+        id: 'train_ticket', name: 'Train Ticket', price: 0,
+        description: 'A ticket for the rails', kind: 'key',
+        usableInField: false, usableInBattle: false, sold: false
+    }
+};
+
+const Items = {
+    get(id) {
+        return ITEMS[id] || null;
+    },
+
+    // Items for sale in the mart, in stable display order.
+    shopInventory() {
+        return Object.values(ITEMS).filter(item => item.sold);
+    },
+
+    // Bag entries the player currently holds that can be used in the field.
+    fieldUsable(player) {
+        return Object.keys(player.items)
+            .filter(id => player.items[id] > 0 && ITEMS[id] && ITEMS[id].usableInField)
+            .map(id => ({ ...ITEMS[id], quantity: player.items[id] }));
+    },
+
+    // Bag entries usable inside battle (potions + capture).
+    battleUsable(player) {
+        return Object.keys(player.items)
+            .filter(id => player.items[id] > 0 && ITEMS[id] && ITEMS[id].usableInBattle)
+            .map(id => ({ ...ITEMS[id], quantity: player.items[id] }));
+    }
+};
+
+// Export
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { ITEMS, Items };
+}

--- a/js/main.js
+++ b/js/main.js
@@ -42,6 +42,13 @@ document.addEventListener('DOMContentLoaded', () => {
             console.log('✅ All assets loaded');
             updateLoadStatus('Assets loaded...', '#ffaa00');
 
+            // Force state to TITLE to ensure we don't get stuck
+            game.state = 'title'; // Use string literal to avoid CONSTANTS dependency if that's the issue
+
+            // Hide load status immediately
+            const loadStatus = document.getElementById('load-status');
+            if (loadStatus) loadStatus.style.display = 'none';
+
             // Initialize mobile controls
             console.log('Initializing mobile controls...');
             updateLoadStatus('Setting up controls...', '#ffaa00');
@@ -67,12 +74,17 @@ document.addEventListener('DOMContentLoaded', () => {
                     // Render
                     game.render();
 
-                    // Continue loop
-                    requestAnimationFrame(gameLoop);
+                    // Clear one-shot "just pressed" input AFTER this frame consumed
+                    // it, so a key can't be re-consumed by a different state next
+                    // frame (prevents phantom/double menu actions across transitions).
+                    game.input.reset();
                 } catch (error) {
                     console.error('❌ Error in game loop:', error);
                     updateLoadStatus(`ERROR: ${error.message}`, '#ff0000');
                 }
+                // ALWAYS re-schedule: one transient throw must not permanently
+                // freeze the game. (Previously the catch skipped the next rAF.)
+                requestAnimationFrame(gameLoop);
             }
 
             // Start game loop AFTER assets are loaded
@@ -81,33 +93,40 @@ document.addEventListener('DOMContentLoaded', () => {
             requestAnimationFrame(gameLoop);
             console.log('✓ Game loop started');
 
-        // Auto-save every 30 seconds
-        setInterval(() => {
-            if (game.player && game.state === CONSTANTS.STATES.OVERWORLD) {
-                game.save();
+            // Auto-save every 30 seconds. Keep the handle so it can be cleared
+            // (and exposed for teardown in tests / re-init).
+            game.autoSaveInterval = setInterval(() => {
+                if (game.player && game.state === CONSTANTS.STATES.OVERWORLD) {
+                    game.save();
+                }
+            }, 30000);
+
+            // Try to load save on start (but stay on title screen if it fails)
+            console.log('Checking for save data...');
+            updateLoadStatus('Loading save...', '#ffaa00');
+            const loadSuccess = game.load();
+            if (loadSuccess) {
+                console.log('📁 Save game loaded!');
+            } else {
+                console.log('💡 No valid save found - starting fresh!');
+                // Ensure we're on the title screen
+                game.state = CONSTANTS.STATES.TITLE;
             }
-        }, 30000);
 
-        // Try to load save on start (but stay on title screen if it fails)
-        console.log('Checking for save data...');
-        updateLoadStatus('Loading save...', '#ffaa00');
-        const loadSuccess = game.load();
-        if (loadSuccess) {
-            console.log('📁 Save game loaded!');
-        } else {
-            console.log('💡 No valid save found - starting fresh!');
-            // Ensure we're on the title screen
-            game.state = CONSTANTS.STATES.TITLE;
-        }
+            console.log('✅ Train Battle RPG Ready!');
+            console.log(`📍 Current state: ${game.state}`);
+            console.log('🎮 Press ENTER on the title screen to start!');
 
-        console.log('✅ Train Battle RPG Ready!');
-        console.log(`📍 Current state: ${game.state}`);
-        console.log('🎮 Press ENTER on the title screen to start!');
+            // Update load status indicator - SUCCESS!
+            updateLoadStatus(`Ready! State: ${game.state}`, '#10b010');
 
-        // Update load status indicator - SUCCESS!
-        updateLoadStatus(`Ready! State: ${game.state}`, '#10b010');
+            // Hide load status after a moment
+            setTimeout(() => {
+                const loadStatus = document.getElementById('load-status');
+                if (loadStatus) loadStatus.style.display = 'none';
+            }, 1000);
 
-    });
+        });
 
     } catch (error) {
         console.error('❌ FATAL ERROR during initialization:', error);

--- a/js/moves.js
+++ b/js/moves.js
@@ -3,38 +3,49 @@
  */
 
 const MOVES_DB = {
-    // Normal/Generic moves
-    "Tackle": { type: "PASSENGER", category: "physical", power: 40, accuracy: 100, pp: 35, effect: null },
-    "Quick Attack": { type: "PASSENGER", category: "physical", power: 40, accuracy: 100, pp: 30, effect: { priority: 1 } },
-    "Body Slam": { type: "PASSENGER", category: "physical", power: 85, accuracy: 100, pp: 15, effect: { paralyze_chance: 30 } },
+    // Normal/Generic moves (PASSENGER type)
+    "Ram": { type: "PASSENGER", category: "physical", power: 40, accuracy: 100, pp: 35, effect: null },
+    "Express Shunt": { type: "PASSENGER", category: "physical", power: 40, accuracy: 100, pp: 30, effect: { priority: 1 } },
+    "Full Throttle": { type: "PASSENGER", category: "physical", power: 85, accuracy: 100, pp: 15, effect: { paralyze_chance: 30 } },
+    "Emergency Brake": { type: "PASSENGER", category: "status", power: 0, accuracy: 100, pp: 30, effect: { raise_defense: 1 } },
+    "Whistle Blast": { type: "PASSENGER", category: "status", power: 0, accuracy: 100, pp: 30, effect: { lower_defense: 1 } },
+    "Wheel Grind": { type: "PASSENGER", category: "status", power: 0, accuracy: 100, pp: 30, effect: { lower_defense: 1 } },
+    "Horn Honk": { type: "PASSENGER", category: "status", power: 0, accuracy: 100, pp: 40, effect: { lower_attack: 1 } },
+    "Track Grease": { type: "PASSENGER", category: "status", power: 0, accuracy: 95, pp: 40, effect: { lower_speed: 1 } },
+    "High Beams": { type: "PASSENGER", category: "status", power: 0, accuracy: 100, pp: 30, effect: { paralyze: 100 } },
+    "Multi-Track Drift": { type: "PASSENGER", category: "physical", power: 15, accuracy: 85, pp: 20, effect: { multi_hit: "2-5" } },
+    "Coupler Crush": { type: "PASSENGER", category: "physical", power: 80, accuracy: 90, pp: 15, effect: { flinch_chance: 10 } },
+    "Derailment": { type: "PASSENGER", category: "physical", power: 0, accuracy: 90, pp: 10, effect: { percentage_damage: 50 } },
+    "Iron Bumper": { type: "PASSENGER", category: "physical", power: 60, accuracy: 100, pp: 25, effect: { flinch_chance: 30 } },
 
     // Steam moves
-    "Whistle": { type: "STEAM", category: "status", power: 0, accuracy: 100, pp: 40, effect: { lower_attack: 1 } },
     "Coal Throw": { type: "STEAM", category: "physical", power: 50, accuracy: 95, pp: 25, effect: { burn_chance: 10 } },
     "Steam Jet": { type: "STEAM", category: "special", power: 65, accuracy: 100, pp: 20, effect: { burn_chance: 20 } },
     "Boiler Burst": { type: "STEAM", category: "special", power: 90, accuracy: 85, pp: 15, effect: { burn_chance: 30 } },
     "Pressure Blast": { type: "STEAM", category: "special", power: 110, accuracy: 80, pp: 10, effect: null },
     "Mega Steam": { type: "STEAM", category: "special", power: 150, accuracy: 90, pp: 5, effect: { recoil: 50 } },
+    "Smoke Screen": { type: "STEAM", category: "status", power: 0, accuracy: 100, pp: 20, effect: { lower_accuracy: 1 } },
 
     // Electric moves
     "Spark": { type: "ELECTRIC", category: "physical", power: 40, accuracy: 100, pp: 30, effect: { paralyze_chance: 10 } },
-    "Thunder Shock": { type: "ELECTRIC", category: "special", power: 40, accuracy: 100, pp: 30, effect: { paralyze_chance: 10 } },
+    "Pantograph Spark": { type: "ELECTRIC", category: "special", power: 40, accuracy: 100, pp: 30, effect: { paralyze_chance: 10 } },
     "Charge Beam": { type: "ELECTRIC", category: "special", power: 65, accuracy: 100, pp: 20, effect: { raise_special: 70 } },
-    "Thunder Wave": { type: "ELECTRIC", category: "status", power: 0, accuracy: 100, pp: 20, effect: { paralyze: 100 } },
+    "Third Rail": { type: "ELECTRIC", category: "status", power: 0, accuracy: 100, pp: 20, effect: { paralyze: 100 } },
     "Rail Gun": { type: "ELECTRIC", category: "special", power: 90, accuracy: 100, pp: 15, effect: null },
     "Lightning Express": { type: "ELECTRIC", category: "special", power: 110, accuracy: 85, pp: 10, effect: null },
-    "Electromagnetic Pulse": { type: "ELECTRIC", category: "special", power: 120, accuracy: 70, pp: 5, effect: { lower_special: 1 } },
-    "Thunder": { type: "ELECTRIC", category: "special", power: 120, accuracy: 70, pp: 10, effect: { paralyze_chance: 30 } },
+    "EMP Blast": { type: "ELECTRIC", category: "special", power: 120, accuracy: 70, pp: 5, effect: { lower_special: 1 } },
+    "Overload": { type: "ELECTRIC", category: "special", power: 120, accuracy: 70, pp: 10, effect: { paralyze_chance: 30 } },
 
     // Diesel moves
     "Diesel Spray": { type: "DIESEL", category: "special", power: 55, accuracy: 95, pp: 25, effect: null },
     "Engine Rev": { type: "DIESEL", category: "status", power: 0, accuracy: 100, pp: 30, effect: { raise_attack: 1 } },
     "Fuel Blast": { type: "DIESEL", category: "special", power: 80, accuracy: 100, pp: 15, effect: null },
     "Turbo Charge": { type: "DIESEL", category: "physical", power: 100, accuracy: 95, pp: 10, effect: null },
+    "Exhaust Fumes": { type: "DIESEL", category: "physical", power: 15, accuracy: 100, pp: 35, effect: { poison_chance: 30 } },
 
     // Freight moves
     "Cargo Toss": { type: "FREIGHT", category: "physical", power: 50, accuracy: 100, pp: 25, effect: null },
-    "Cargo Cannon": { type: "FREIGHT", category: "physical", power: 70, accuracy: 95, pp: 20, effect: null },
+    "Boxcar Bash": { type: "FREIGHT", category: "physical", power: 70, accuracy: 95, pp: 20, effect: null },
     "Container Crush": { type: "FREIGHT", category: "physical", power: 85, accuracy: 100, pp: 15, effect: null },
     "Freight Frenzy": { type: "FREIGHT", category: "physical", power: 120, accuracy: 100, pp: 10, effect: { must_recharge: true } },
     "Heavy Haul": { type: "FREIGHT", category: "physical", power: 100, accuracy: 90, pp: 10, effect: null },
@@ -42,40 +53,29 @@ const MOVES_DB = {
     // Maglev moves
     "Maglev Rush": { type: "MAGLEV", category: "physical", power: 80, accuracy: 100, pp: 15, effect: null },
     "Magnetic Pulse": { type: "MAGLEV", category: "special", power: 90, accuracy: 95, pp: 10, effect: null },
-    "Gust": { type: "MAGLEV", category: "special", power: 40, accuracy: 100, pp: 35, effect: null },
-    "Wing Attack": { type: "MAGLEV", category: "physical", power: 60, accuracy: 100, pp: 35, effect: null },
+    "Levitation": { type: "MAGLEV", category: "special", power: 40, accuracy: 100, pp: 35, effect: null },
+    "Sonic Boom": { type: "MAGLEV", category: "physical", power: 60, accuracy: 100, pp: 35, effect: null },
+    "Signal Jam": { type: "MAGLEV", category: "special", power: 50, accuracy: 100, pp: 25, effect: { confuse_chance: 10 } },
 
     // Passenger moves
     "Passenger Rush": { type: "PASSENGER", category: "physical", power: 75, accuracy: 100, pp: 20, effect: null },
     "Express Service": { type: "PASSENGER", category: "special", power: 95, accuracy: 100, pp: 10, effect: { priority: 1 } },
-    "Hyper Fang": { type: "PASSENGER", category: "physical", power: 80, accuracy: 90, pp: 15, effect: { flinch_chance: 10 } },
-    "Super Fang": { type: "PASSENGER", category: "physical", power: 0, accuracy: 90, pp: 10, effect: { percentage_damage: 50 } },
-    "Bite": { type: "PASSENGER", category: "physical", power: 60, accuracy: 100, pp: 25, effect: { flinch_chance: 30 } },
 
     // Monorail moves
-    "Peck": { type: "MONORAIL", category: "physical", power: 35, accuracy: 100, pp: 35, effect: null },
-    "Drill Peck": { type: "MONORAIL", category: "physical", power: 80, accuracy: 100, pp: 20, effect: null },
+    "Mono-Strike": { type: "MONORAIL", category: "physical", power: 35, accuracy: 100, pp: 35, effect: null },
+    "Beam Balance": { type: "MONORAIL", category: "physical", power: 80, accuracy: 100, pp: 20, effect: null },
 
     // Nuclear moves
-    "Radiation": { type: "NUCLEAR", category: "special", power: 65, accuracy: 100, pp: 20, effect: { poison_chance: 30 } },
-    "Atomic Blast": { type: "NUCLEAR", category: "special", power: 120, accuracy: 90, pp: 5, effect: { recoil: 33 } },
-
-    // Status moves
-    "Harden": { type: "PASSENGER", category: "status", power: 0, accuracy: 100, pp: 30, effect: { raise_defense: 1 } },
-    "Leer": { type: "PASSENGER", category: "status", power: 0, accuracy: 100, pp: 30, effect: { lower_defense: 1 } },
-    "Tail Whip": { type: "PASSENGER", category: "status", power: 0, accuracy: 100, pp: 30, effect: { lower_defense: 1 } },
-    "Growl": { type: "PASSENGER", category: "status", power: 0, accuracy: 100, pp: 40, effect: { lower_attack: 1 } },
-    "String Shot": { type: "PASSENGER", category: "status", power: 0, accuracy: 95, pp: 40, effect: { lower_speed: 1 } },
-    "Glare": { type: "PASSENGER", category: "status", power: 0, accuracy: 100, pp: 30, effect: { paralyze: 100 } },
-    "Confusion": { type: "MAGLEV", category: "special", power: 50, accuracy: 100, pp: 25, effect: { confuse_chance: 10 } },
-    "Fury Attack": { type: "PASSENGER", category: "physical", power: 15, accuracy: 85, pp: 20, effect: { multi_hit: "2-5" } },
-    "Poison Sting": { type: "DIESEL", category: "physical", power: 15, accuracy: 100, pp: 35, effect: { poison_chance: 30 } },
+    "Radiation Leak": { type: "NUCLEAR", category: "special", power: 65, accuracy: 100, pp: 20, effect: { poison_chance: 30 } },
+    "Reactor Meltdown": { type: "NUCLEAR", category: "special", power: 120, accuracy: 90, pp: 5, effect: { recoil: 33 } },
 };
 
 /**
  * Calculate damage using Gen 1 Pokemon formula
  */
-function calculateDamage(attacker, defender, moveName) {
+// opts.attackStat / opts.defenseStat let the caller pass stage-adjusted stats
+// (Gen-1 stat stages live in the Battle, not on the Train instance).
+function calculateDamage(attacker, defender, moveName, opts = {}) {
     const moveData = MOVES_DB[moveName];
 
     // Status moves don't do damage
@@ -89,12 +89,14 @@ function calculateDamage(attacker, defender, moveName) {
         return { damage: 0, critical: false, effectiveness: 1.0, hit: false };
     }
 
-    // Special damage calculations
+    // Fixed/percentage damage still respects type immunity (0x) - a move that
+    // "can't touch" a type should not chip a fixed 50% off it.
     if (moveData.effect && moveData.effect.percentage_damage) {
+        const eff = getTypeEffectiveness(moveData.type, defender.types);
         return {
-            damage: Math.floor(defender.currentHP * moveData.effect.percentage_damage / 100),
+            damage: eff === 0 ? 0 : Math.floor(defender.currentHP * moveData.effect.percentage_damage / 100),
             critical: false,
-            effectiveness: 1.0,
+            effectiveness: eff,
             hit: true
         };
     }
@@ -103,14 +105,14 @@ function calculateDamage(attacker, defender, moveName) {
     const level = attacker.level;
     const power = moveData.power;
 
-    // Determine if physical or special
+    // Determine if physical or special (caller may override with staged stats)
     let attack, defense;
     if (moveData.category === "physical") {
-        attack = attacker.attack;
-        defense = defender.defense;
+        attack = opts.attackStat != null ? opts.attackStat : attacker.attack;
+        defense = opts.defenseStat != null ? opts.defenseStat : defender.defense;
     } else {
-        attack = attacker.special;
-        defense = defender.special;
+        attack = opts.attackStat != null ? opts.attackStat : attacker.special;
+        defense = opts.defenseStat != null ? opts.defenseStat : defender.special;
     }
 
     // Base damage formula (Gen 1)

--- a/js/player.js
+++ b/js/player.js
@@ -109,9 +109,14 @@ class Player {
         return this.party.some(train => !train.fainted);
     }
 
+    // Single canonical heal: full HP, clear status, revive fainted.
+    // (healAllTrains is kept as an alias below for older call sites.)
     healParty() {
         for (const train of this.party) {
-            train.heal(train.maxHP);
+            if (!train || typeof train.maxHP === 'undefined') continue;
+            train.currentHP = train.maxHP;
+            train.status = null;
+            train.fainted = false;
         }
     }
 
@@ -132,7 +137,16 @@ class Player {
     }
 
     addMoney(amount) {
-        this.money = Math.max(0, this.money + amount);
+        this.money = Math.max(0, this.money + Math.floor(amount));
+    }
+
+    // Returns true and deducts if affordable; false otherwise. The single
+    // gate for spending so money can never be driven negative.
+    spendMoney(amount) {
+        amount = Math.floor(amount);
+        if (amount < 0 || this.money < amount) return false;
+        this.money -= amount;
+        return true;
     }
 
     earnBadge(badgeName) {
@@ -148,27 +162,14 @@ class Player {
         return this.badges.includes(badgeName);
     }
 
+    // Alias kept for backwards compatibility - delegates to the canonical heal.
     healAllTrains() {
-        // Heal all trains in party to full HP and remove status effects
-        if (!this.party || this.party.length === 0) {
-            console.log('No trains to heal!');
-            return;
-        }
-
-        for (let train of this.party) {
-            if (!train || typeof train.maxHP === 'undefined') {
-                console.warn('Skipping invalid train:', train);
-                continue;
-            }
-            train.currentHP = train.maxHP; // Use maxHP, not stats.hp
-            train.status = null;
-            train.fainted = false;
-        }
-        console.log('All trains healed to full HP!');
+        this.healParty();
     }
 
     toJSON() {
         return {
+            version: Player.SAVE_VERSION,
             name: this.name,
             x: this.x,
             y: this.y,
@@ -187,22 +188,38 @@ class Player {
 
     static fromJSON(data) {
         const player = new Player();
-        player.name = data.name;
-        player.x = data.x;
-        player.y = data.y;
-        player.direction = data.direction;
-        player.currentMap = data.currentMap;
-        player.party = data.party.map(t => Train.fromJSON(t));
-        player.items = data.items;
-        player.money = data.money;
+        if (!data) return player;
+
+        player.name = data.name ?? player.name;
+        player.x = data.x ?? player.x;
+        player.y = data.y ?? player.y;
+        player.direction = data.direction ?? player.direction;
+        player.currentMap = data.currentMap ?? player.currentMap;
+
+        // Party: guard against missing/empty and drop any entry that fails to
+        // deserialize rather than throwing out the whole save.
+        player.party = Array.isArray(data.party)
+            ? data.party.map(t => {
+                try { return Train.fromJSON(t); } catch (e) { console.warn('Bad train in save, skipped:', e); return null; }
+            }).filter(Boolean)
+            : [];
+
+        // Merge saved items OVER the constructor defaults so keys added in a
+        // newer build (future items) are still present after loading an old save.
+        player.items = { ...player.items, ...(data.items || {}) };
+
+        player.money = typeof data.money === 'number' ? data.money : player.money;
         player.badges = data.badges || [];
-        player.badgeCount = data.badgeCount || 0;
+        player.badgeCount = data.badgeCount || player.badges.length;
         player.hasStarterTrain = data.hasStarterTrain || false;
         player.metProfessor = data.metProfessor || false;
         player.defeatedGymLeaders = data.defeatedGymLeaders || [];
         return player;
     }
 }
+
+// Bump when the save shape changes incompatibly so loaders can migrate.
+Player.SAVE_VERSION = 1;
 
 // Export
 if (typeof module !== 'undefined' && module.exports) {

--- a/js/train-data.js
+++ b/js/train-data.js
@@ -9,7 +9,7 @@ const TRAIN_SPECIES = {
         types: ["STEAM"],
         baseStats: { hp: 45, attack: 49, defense: 49, speed: 45, special: 65 },
         learnset: [
-            { level: 1, move: "Coal Throw" },
+            { level: 1, move: "Ram" },
             { level: 7, move: "Steam Jet" },
             { level: 13, move: "Boiler Burst" },
             { level: 20, move: "Pressure Blast" }
@@ -24,7 +24,7 @@ const TRAIN_SPECIES = {
         types: ["STEAM"],
         baseStats: { hp: 60, attack: 62, defense: 63, speed: 60, special: 80 },
         learnset: [
-            { level: 1, move: "Coal Throw" },
+            { level: 1, move: "Ram" },
             { level: 7, move: "Steam Jet" },
             { level: 13, move: "Boiler Burst" },
             { level: 20, move: "Pressure Blast" },
@@ -40,7 +40,7 @@ const TRAIN_SPECIES = {
         types: ["STEAM", "FREIGHT"],
         baseStats: { hp: 80, attack: 82, defense: 83, speed: 80, special: 100 },
         learnset: [
-            { level: 1, move: "Coal Throw" },
+            { level: 1, move: "Ram" },
             { level: 7, move: "Steam Jet" },
             { level: 13, move: "Boiler Burst" },
             { level: 20, move: "Pressure Blast" },
@@ -59,7 +59,7 @@ const TRAIN_SPECIES = {
         learnset: [
             { level: 1, move: "Spark" },
             { level: 9, move: "Charge Beam" },
-            { level: 15, move: "Thunder Wave" },
+            { level: 15, move: "Third Rail" },
             { level: 22, move: "Rail Gun" }
         ],
         evolution: { method: "level", level: 16, evolvesTo: 5 },
@@ -74,7 +74,7 @@ const TRAIN_SPECIES = {
         learnset: [
             { level: 1, move: "Spark" },
             { level: 9, move: "Charge Beam" },
-            { level: 15, move: "Thunder Wave" },
+            { level: 15, move: "Third Rail" },
             { level: 22, move: "Rail Gun" },
             { level: 36, move: "Lightning Express" }
         ],
@@ -90,10 +90,10 @@ const TRAIN_SPECIES = {
         learnset: [
             { level: 1, move: "Spark" },
             { level: 9, move: "Charge Beam" },
-            { level: 15, move: "Thunder Wave" },
+            { level: 15, move: "Third Rail" },
             { level: 22, move: "Rail Gun" },
             { level: 36, move: "Lightning Express" },
-            { level: 52, move: "Electromagnetic Pulse" }
+            { level: 52, move: "EMP Blast" }
         ],
         evolution: null,
         catchRate: 45,
@@ -105,7 +105,7 @@ const TRAIN_SPECIES = {
         types: ["DIESEL"],
         baseStats: { hp: 44, attack: 48, defense: 65, speed: 43, special: 50 },
         learnset: [
-            { level: 1, move: "Tackle" },
+            { level: 1, move: "Ram" },
             { level: 8, move: "Diesel Spray" },
             { level: 15, move: "Engine Rev" },
             { level: 22, move: "Fuel Blast" }
@@ -120,7 +120,7 @@ const TRAIN_SPECIES = {
         types: ["DIESEL"],
         baseStats: { hp: 59, attack: 63, defense: 80, speed: 58, special: 65 },
         learnset: [
-            { level: 1, move: "Tackle" },
+            { level: 1, move: "Ram" },
             { level: 8, move: "Diesel Spray" },
             { level: 15, move: "Engine Rev" },
             { level: 22, move: "Fuel Blast" },
@@ -136,7 +136,7 @@ const TRAIN_SPECIES = {
         types: ["DIESEL", "FREIGHT"],
         baseStats: { hp: 79, attack: 83, defense: 100, speed: 78, special: 85 },
         learnset: [
-            { level: 1, move: "Tackle" },
+            { level: 1, move: "Ram" },
             { level: 8, move: "Diesel Spray" },
             { level: 15, move: "Engine Rev" },
             { level: 22, move: "Fuel Blast" },
@@ -153,8 +153,8 @@ const TRAIN_SPECIES = {
         types: ["PASSENGER"],
         baseStats: { hp: 45, attack: 30, defense: 35, speed: 45, special: 20 },
         learnset: [
-            { level: 1, move: "Tackle" },
-            { level: 9, move: "String Shot" }
+            { level: 1, move: "Ram" },
+            { level: 9, move: "Track Grease" }
         ],
         evolution: { method: "level", level: 7, evolvesTo: 11 },
         catchRate: 255,
@@ -165,7 +165,7 @@ const TRAIN_SPECIES = {
         name: "Coachoon",
         types: ["PASSENGER"],
         baseStats: { hp: 50, attack: 20, defense: 55, speed: 30, special: 25 },
-        learnset: [{ level: 1, move: "Harden" }],
+        learnset: [{ level: 1, move: "Emergency Brake" }],
         evolution: { method: "level", level: 10, evolvesTo: 12 },
         catchRate: 120,
         expYield: 72
@@ -176,8 +176,8 @@ const TRAIN_SPECIES = {
         types: ["PASSENGER", "MAGLEV"],
         baseStats: { hp: 60, attack: 45, defense: 50, speed: 70, special: 90 },
         learnset: [
-            { level: 10, move: "Confusion" },
-            { level: 13, move: "Gust" },
+            { level: 10, move: "Signal Jam" },
+            { level: 13, move: "Levitation" },
             { level: 17, move: "Passenger Rush" },
             { level: 25, move: "Express Service" }
         ],
@@ -186,20 +186,20 @@ const TRAIN_SPECIES = {
         expYield: 178
     },
     // Continue with remaining trains (13-151)
-    13: { id: 13, name: "Cartle", types: ["FREIGHT"], baseStats: { hp: 40, attack: 35, defense: 30, speed: 50, special: 20 }, learnset: [{ level: 1, move: "Tackle" }], evolution: { method: "level", level: 7, evolvesTo: 14 }, catchRate: 255, expYield: 52 },
-    14: { id: 14, name: "Haulkoon", types: ["FREIGHT"], baseStats: { hp: 45, attack: 25, defense: 50, speed: 35, special: 25 }, learnset: [{ level: 1, move: "Harden" }], evolution: { method: "level", level: 10, evolvesTo: 15 }, catchRate: 120, expYield: 71 },
-    15: { id: 15, name: "Cargodrill", types: ["FREIGHT", "DIESEL"], baseStats: { hp: 65, attack: 90, defense: 40, speed: 75, special: 45 }, learnset: [{ level: 10, move: "Fury Attack" }], evolution: null, catchRate: 45, expYield: 178 },
-    16: { id: 16, name: "Railoo", types: ["PASSENGER"], baseStats: { hp: 40, attack: 45, defense: 40, speed: 56, special: 35 }, learnset: [{ level: 1, move: "Tackle" }], evolution: { method: "level", level: 18, evolvesTo: 17 }, catchRate: 255, expYield: 55 },
-    17: { id: 17, name: "Raileon", types: ["PASSENGER"], baseStats: { hp: 63, attack: 60, defense: 55, speed: 71, special: 50 }, learnset: [{ level: 1, move: "Tackle" }], evolution: { method: "level", level: 36, evolvesTo: 18 }, catchRate: 120, expYield: 113 },
-    18: { id: 18, name: "Railgeot", types: ["PASSENGER", "MAGLEV"], baseStats: { hp: 83, attack: 80, defense: 75, speed: 101, special: 70 }, learnset: [{ level: 1, move: "Tackle" }], evolution: null, catchRate: 45, expYield: 216 },
-    19: { id: 19, name: "Trackat", types: ["PASSENGER"], baseStats: { hp: 30, attack: 56, defense: 35, speed: 72, special: 25 }, learnset: [{ level: 1, move: "Tackle" }], evolution: { method: "level", level: 20, evolvesTo: 20 }, catchRate: 255, expYield: 57 },
-    20: { id: 20, name: "Railcate", types: ["PASSENGER"], baseStats: { hp: 55, attack: 81, defense: 60, speed: 97, special: 50 }, learnset: [{ level: 1, move: "Tackle" }], evolution: null, catchRate: 127, expYield: 116 },
-    21: { id: 21, name: "Monowl", types: ["MONORAIL", "PASSENGER"], baseStats: { hp: 40, attack: 60, defense: 30, speed: 70, special: 31 }, learnset: [{ level: 1, move: "Peck" }], evolution: { method: "level", level: 20, evolvesTo: 22 }, catchRate: 255, expYield: 58 },
-    22: { id: 22, name: "Monoking", types: ["MONORAIL", "PASSENGER"], baseStats: { hp: 65, attack: 90, defense: 65, speed: 100, special: 61 }, learnset: [{ level: 1, move: "Peck" }], evolution: null, catchRate: 90, expYield: 162 },
-    23: { id: 23, name: "Tunnela", types: ["DIESEL"], baseStats: { hp: 35, attack: 60, defense: 44, speed: 55, special: 40 }, learnset: [{ level: 1, move: "Tackle" }], evolution: { method: "level", level: 22, evolvesTo: 24 }, catchRate: 255, expYield: 62 },
-    24: { id: 24, name: "Cobraloco", types: ["DIESEL"], baseStats: { hp: 60, attack: 95, defense: 69, speed: 80, special: 65 }, learnset: [{ level: 1, move: "Tackle" }], evolution: null, catchRate: 90, expYield: 147 },
-    25: { id: 25, name: "Zaptram", types: ["ELECTRIC"], baseStats: { hp: 35, attack: 55, defense: 40, speed: 90, special: 50 }, learnset: [{ level: 1, move: "Thunder Shock" }], evolution: { method: "item", item: "thunder_stone", evolvesTo: 26 }, catchRate: 190, expYield: 112 },
-    26: { id: 26, name: "Raitram", types: ["ELECTRIC"], baseStats: { hp: 60, attack: 90, defense: 55, speed: 110, special: 90 }, learnset: [{ level: 1, move: "Thunder Shock" }], evolution: null, catchRate: 75, expYield: 218 },
+    13: { id: 13, name: "Cartle", types: ["FREIGHT"], baseStats: { hp: 40, attack: 35, defense: 30, speed: 50, special: 20 }, learnset: [{ level: 1, move: "Ram" }], evolution: { method: "level", level: 7, evolvesTo: 14 }, catchRate: 255, expYield: 52 },
+    14: { id: 14, name: "Haulkoon", types: ["FREIGHT"], baseStats: { hp: 45, attack: 25, defense: 50, speed: 35, special: 25 }, learnset: [{ level: 1, move: "Emergency Brake" }], evolution: { method: "level", level: 10, evolvesTo: 15 }, catchRate: 120, expYield: 71 },
+    15: { id: 15, name: "Cargodrill", types: ["FREIGHT", "DIESEL"], baseStats: { hp: 65, attack: 90, defense: 40, speed: 75, special: 45 }, learnset: [{ level: 10, move: "Multi-Track Drift" }], evolution: null, catchRate: 45, expYield: 178 },
+    16: { id: 16, name: "Railoo", types: ["PASSENGER"], baseStats: { hp: 40, attack: 45, defense: 40, speed: 56, special: 35 }, learnset: [{ level: 1, move: "Ram" }], evolution: { method: "level", level: 18, evolvesTo: 17 }, catchRate: 255, expYield: 55 },
+    17: { id: 17, name: "Raileon", types: ["PASSENGER"], baseStats: { hp: 63, attack: 60, defense: 55, speed: 71, special: 50 }, learnset: [{ level: 1, move: "Ram" }], evolution: { method: "level", level: 36, evolvesTo: 18 }, catchRate: 120, expYield: 113 },
+    18: { id: 18, name: "Railgeot", types: ["PASSENGER", "MAGLEV"], baseStats: { hp: 83, attack: 80, defense: 75, speed: 101, special: 70 }, learnset: [{ level: 1, move: "Ram" }], evolution: null, catchRate: 45, expYield: 216 },
+    19: { id: 19, name: "Trackat", types: ["PASSENGER"], baseStats: { hp: 30, attack: 56, defense: 35, speed: 72, special: 25 }, learnset: [{ level: 1, move: "Ram" }], evolution: { method: "level", level: 20, evolvesTo: 20 }, catchRate: 255, expYield: 57 },
+    20: { id: 20, name: "Railcate", types: ["PASSENGER"], baseStats: { hp: 55, attack: 81, defense: 60, speed: 97, special: 50 }, learnset: [{ level: 1, move: "Ram" }], evolution: null, catchRate: 127, expYield: 116 },
+    21: { id: 21, name: "Monowl", types: ["MONORAIL", "PASSENGER"], baseStats: { hp: 40, attack: 60, defense: 30, speed: 70, special: 31 }, learnset: [{ level: 1, move: "Mono-Strike" }], evolution: { method: "level", level: 20, evolvesTo: 22 }, catchRate: 255, expYield: 58 },
+    22: { id: 22, name: "Monoking", types: ["MONORAIL", "PASSENGER"], baseStats: { hp: 65, attack: 90, defense: 65, speed: 100, special: 61 }, learnset: [{ level: 1, move: "Mono-Strike" }], evolution: null, catchRate: 90, expYield: 162 },
+    23: { id: 23, name: "Tunnela", types: ["DIESEL"], baseStats: { hp: 35, attack: 60, defense: 44, speed: 55, special: 40 }, learnset: [{ level: 1, move: "Ram" }], evolution: { method: "level", level: 22, evolvesTo: 24 }, catchRate: 255, expYield: 62 },
+    24: { id: 24, name: "Cobraloco", types: ["DIESEL"], baseStats: { hp: 60, attack: 95, defense: 69, speed: 80, special: 65 }, learnset: [{ level: 1, move: "Ram" }], evolution: null, catchRate: 90, expYield: 147 },
+    25: { id: 25, name: "Zaptram", types: ["ELECTRIC"], baseStats: { hp: 35, attack: 55, defense: 40, speed: 90, special: 50 }, learnset: [{ level: 1, move: "Pantograph Spark" }], evolution: { method: "item", item: "thunder_stone", evolvesTo: 26 }, catchRate: 190, expYield: 112 },
+    26: { id: 26, name: "Raitram", types: ["ELECTRIC"], baseStats: { hp: 60, attack: 90, defense: 55, speed: 110, special: 90 }, learnset: [{ level: 1, move: "Pantograph Spark" }], evolution: null, catchRate: 75, expYield: 218 },
 };
 
 // Clever train names for all 151 trains!
@@ -239,27 +239,48 @@ const TRAIN_NAMES = {
 };
 
 // Generate remaining trains (27-151) with clever names!
+//
+// IMPORTANT: generation is DETERMINISTIC. Each species is built from a PRNG
+// seeded by its own id, so a given train (e.g. #88 "Firetruck") has identical
+// types/stats/catch-rate on every page load. This is a save-integrity
+// requirement: a train saved one session must deserialize against the same
+// template the next session. (Previously these used Math.random()/randomInt
+// at module load, so species silently differed run-to-run.)
+//
 // Catch rates follow Pokemon Gen 1 logic:
-// - Starters/legendaries: 45
-// - Common trains: 190-255
-// - Uncommon: 90-190
+// - Legendaries (150-151): 45
+// - Uncommon (100-149): 90-190
+// - Common (27-99): 190-255
+
+// mulberry32 - tiny deterministic PRNG. Same seed -> same sequence.
+function seededRng(seed) {
+    let a = seed >>> 0;
+    return function () {
+        a |= 0; a = (a + 0x6D2B79F5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
 for (let i = 27; i <= 151; i++) {
-    const types = [Utils.randomChoice(CONSTANTS.TYPES)];
-    if (Math.random() > 0.7) {
-        types.push(Utils.randomChoice(CONSTANTS.TYPES.filter(t => t !== types[0])));
+    // Seed offset keeps the stream clear of small-int collisions.
+    const rand = seededRng(i * 2654435761);
+    const randInt = (min, max) => Math.floor(rand() * (max - min + 1)) + min;
+    const pick = (arr) => arr[Math.floor(rand() * arr.length)];
+
+    const types = [pick(CONSTANTS.TYPES)];
+    if (rand() > 0.7) {
+        types.push(pick(CONSTANTS.TYPES.filter(t => t !== types[0])));
     }
 
-    // Determine catch rate based on train ID
-    // Legendary trains (150-151): 45
-    // Uncommon trains (100-149): 90-190
-    // Common trains (27-99): 190-255
     let catchRate;
     if (i >= 150) {
         catchRate = 45; // Legendary
     } else if (i >= 100) {
-        catchRate = Utils.randomInt(90, 190); // Uncommon
+        catchRate = randInt(90, 190); // Uncommon
     } else {
-        catchRate = Utils.randomInt(190, 255); // Common
+        catchRate = randInt(190, 255); // Common
     }
 
     TRAIN_SPECIES[i] = {
@@ -267,20 +288,20 @@ for (let i = 27; i <= 151; i++) {
         name: TRAIN_NAMES[i] || `Train${String(i).padStart(3, '0')}`,
         types: types,
         baseStats: {
-            hp: Utils.randomInt(30, 120),
-            attack: Utils.randomInt(30, 120),
-            defense: Utils.randomInt(30, 120),
-            speed: Utils.randomInt(30, 120),
-            special: Utils.randomInt(30, 120)
+            hp: randInt(30, 120),
+            attack: randInt(30, 120),
+            defense: randInt(30, 120),
+            speed: randInt(30, 120),
+            special: randInt(30, 120)
         },
         learnset: [
-            { level: 1, move: "Tackle" },
-            { level: 10, move: "Quick Attack" },
-            { level: 20, move: "Body Slam" }
+            { level: 1, move: "Ram" },
+            { level: 10, move: "Express Shunt" },
+            { level: 20, move: "Full Throttle" }
         ],
         evolution: null,
         catchRate: catchRate,
-        expYield: Utils.randomInt(50, 250)
+        expYield: randInt(50, 250)
     };
 }
 

--- a/js/train.js
+++ b/js/train.js
@@ -39,8 +39,10 @@ class Train {
         this.status = null;
         this.fainted = false;
 
-        // Types
-        this.types = this.species.types;
+        // Types - CLONE the template array. `this.species` is a shared
+        // read-only template; aliasing its arrays would let a type-changing
+        // move corrupt every train of this species. Always copy mutable state.
+        this.types = [...this.species.types];
     }
 
     calculateStat(statName) {
@@ -118,7 +120,7 @@ class Train {
                 moves.push(moveData.move);
             }
         }
-        return moves.length > 0 ? moves : ["Tackle"];
+        return moves.length > 0 ? moves : ["Ram"];
     }
 
     takeDamage(damage) {
@@ -146,23 +148,26 @@ class Train {
         return CONSTANTS.COLORS.HP_RED;
     }
 
-    canEvolve() {
+    // context may carry { item } for stone-style evolutions.
+    canEvolve(context = {}) {
         const evolution = this.species.evolution;
-        if (evolution) {
-            if (evolution.method === 'level' && this.level >= evolution.level) {
-                return true;
-            }
+        if (!evolution) return false;
+        if (evolution.method === 'level') {
+            return this.level >= evolution.level;
+        }
+        if (evolution.method === 'item') {
+            return context.item === evolution.item;
         }
         return false;
     }
 
-    evolve() {
+    evolve(context = {}) {
         const evolution = this.species.evolution;
-        if (evolution && this.canEvolve()) {
+        if (evolution && this.canEvolve(context)) {
             this.speciesId = evolution.evolvesTo;
             this.species = TRAIN_SPECIES[this.speciesId];
             this.nickname = this.species.name;
-            this.types = this.species.types;
+            this.types = [...this.species.types];
 
             // Update base stats
             this.baseHP = this.species.baseStats.hp;

--- a/js/ui.js
+++ b/js/ui.js
@@ -234,8 +234,8 @@ class UI {
                 ctx.fillStyle = CONSTANTS.COLORS.BLACK;
             }
 
-            const hpPercent = Math.floor((train.currentHP / train.stats.hp) * 100);
-            ctx.fillText(`${train.name} Lv${train.level} HP: ${train.currentHP}/${train.stats.hp} (${hpPercent}%)`, x + 20, trainY);
+            const hpPercent = Math.floor((train.currentHP / train.maxHP) * 100);
+            ctx.fillText(`${train.nickname || train.species.name} Lv${train.level} HP: ${train.currentHP}/${train.maxHP} (${hpPercent}%)`, x + 20, trainY);
         }
 
         // Instructions
@@ -332,8 +332,8 @@ class UI {
                 ctx.fillStyle = CONSTANTS.COLORS.BLACK;
             }
 
-            const hpPercent = Math.floor((train.currentHP / train.stats.hp) * 100);
-            ctx.fillText(`${train.name} Lv${train.level} HP: ${train.currentHP}/${train.stats.hp} (${hpPercent}%)`, x + 20, trainY);
+            const hpPercent = Math.floor((train.currentHP / train.maxHP) * 100);
+            ctx.fillText(`${train.nickname || train.species.name} Lv${train.level} HP: ${train.currentHP}/${train.maxHP} (${hpPercent}%)`, x + 20, trainY);
         }
 
         // Instructions

--- a/specs/.temper-namespace
+++ b/specs/.temper-namespace
@@ -1,0 +1,1 @@
+Conducted

--- a/specs/0001-battle/battle.ioa.toml
+++ b/specs/0001-battle/battle.ioa.toml
@@ -1,0 +1,117 @@
+# spec 0001 - Battle I/O Automaton
+#
+# Models the battle lifecycle - a battle is created, runs turns, resolves
+# exactly once, and is torn down - per DESIGN.md §3. The bools encode the §3
+# contracts; the active_end_resolution_count <= 1 invariant is the formal
+# statement of "single end-of-battle owner" (the double-resolution bug the
+# rewrite fixed).
+#
+# Verified by `temper verify -s specs/0001-battle/`.
+
+[automaton]
+name = "Battle"
+states = ["Drafted", "Engaged", "Resolved", "Retired"]
+initial = "Drafted"
+
+# ─────────────────────────── State variables ───────────────────────────
+
+[[state]]
+name = "single_end_of_battle_owner_checkbattleend_per_section_3"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "turn_order_by_priority_then_effective_speed_per_section_3"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "damage_computed_at_resolution_time_per_section_3"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "faint_interrupts_remaining_turn_actions_per_section_3"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "exp_awarded_once_per_defeated_enemy_per_section_3"
+type = "bool"
+initial = "false"
+
+# In-flight end-of-battle resolutions. The <= 1 invariant is the formal
+# "exactly one owner resolves the battle" guarantee.
+[[state]]
+name = "active_end_resolution_count"
+type = "counter"
+initial = "0"
+
+# ─────────────────────────── Actions ───────────────────────────
+
+[[action]]
+name = "AttestBattleContract"
+kind = "input"
+from = ["Drafted"]
+params = ["attestor"]
+guard = "is_false exp_awarded_once_per_defeated_enemy_per_section_3"
+effect = [
+  { type = "set_bool", var = "single_end_of_battle_owner_checkbattleend_per_section_3", value = true },
+  { type = "set_bool", var = "turn_order_by_priority_then_effective_speed_per_section_3", value = true },
+  { type = "set_bool", var = "damage_computed_at_resolution_time_per_section_3", value = true },
+  { type = "set_bool", var = "faint_interrupts_remaining_turn_actions_per_section_3", value = true },
+  { type = "set_bool", var = "exp_awarded_once_per_defeated_enemy_per_section_3", value = true },
+]
+hint = "Battle engine asserts the §3 turn/resolution contracts before any turn runs."
+
+[[action]]
+name = "Engage"
+kind = "input"
+from = ["Drafted"]
+to = "Engaged"
+params = ["encounter_id"]
+guard = [
+  { type = "is_true", var = "single_end_of_battle_owner_checkbattleend_per_section_3" },
+  { type = "is_true", var = "turn_order_by_priority_then_effective_speed_per_section_3" },
+  { type = "is_true", var = "damage_computed_at_resolution_time_per_section_3" },
+  { type = "is_true", var = "faint_interrupts_remaining_turn_actions_per_section_3" },
+  { type = "is_true", var = "exp_awarded_once_per_defeated_enemy_per_section_3" },
+]
+hint = "Intro done and all §3 contracts attested; turns begin."
+
+[[action]]
+name = "Resolve"
+kind = "input"
+from = ["Engaged"]
+to = "Resolved"
+params = ["outcome"]
+effect = { type = "increment", var = "active_end_resolution_count" }
+hint = "The single owner (checkBattleEnd) resolves victory/defeat exactly once per §3."
+
+[[action]]
+name = "Retire"
+kind = "input"
+from = ["Resolved"]
+to = "Retired"
+params = ["successor_id"]
+effect = { type = "decrement", var = "active_end_resolution_count" }
+hint = "Battle torn down; control returns to the overworld."
+
+# ─────────────────────────── Invariants ───────────────────────────
+
+[[invariant]]
+name = "AtMostOneEndResolution"
+assert = "active_end_resolution_count <= 1"
+
+[[invariant]]
+name = "MustEngageBeforeResolve"
+assert = "ordering(Engaged, Resolved)"
+
+[[invariant]]
+name = "MustResolveBeforeRetire"
+assert = "ordering(Resolved, Retired)"
+
+[[invariant]]
+name = "RetiredIsTerminal"
+when = ["Retired"]
+assert = "no_further_transitions"

--- a/specs/0001-battle/model.csdl.xml
+++ b/specs/0001-battle/model.csdl.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Spec 0001 Battle - CSDL companion to battle.ioa.toml (DESIGN.md §3).
+  Filename MUST be literally `model.csdl.xml`. Mirror every IOA [[state]] as a
+  <Property> and every [[action]] as an <Action>; names must match exactly.
+-->
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+
+    <Schema Namespace="Temper.Vocab" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <Term Name="StateMachine.States" Type="Collection(Edm.String)" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.InitialState" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.ValidFromStates" Type="Collection(Edm.String)" AppliesTo="Action"/>
+      <Term Name="StateMachine.TargetState" Type="Edm.String" AppliesTo="Action"/>
+      <Term Name="Agent.Hint" Type="Edm.String" AppliesTo="Action EntityType"/>
+      <Term Name="ShardKey" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="AuthZ.CedarPolicy" Type="Edm.String" AppliesTo="EntityType Action"/>
+    </Schema>
+
+    <Schema Namespace="Conducted.Battle" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+
+      <EnumType Name="BattleStatus">
+        <Member Name="Drafted" Value="0"/>
+        <Member Name="Engaged" Value="1"/>
+        <Member Name="Resolved" Value="2"/>
+        <Member Name="Retired" Value="3"/>
+      </EnumType>
+
+      <EntityType Name="Battle">
+        <Key>
+          <PropertyRef Name="BattleId"/>
+        </Key>
+        <Property Name="BattleId" Type="Edm.String" Nullable="false"/>
+        <Property Name="UserId" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Conducted.Battle.BattleStatus" Nullable="false"/>
+
+        <Property Name="single_end_of_battle_owner_checkbattleend_per_section_3" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="turn_order_by_priority_then_effective_speed_per_section_3" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="damage_computed_at_resolution_time_per_section_3" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="faint_interrupts_remaining_turn_actions_per_section_3" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="exp_awarded_once_per_defeated_enemy_per_section_3" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="active_end_resolution_count" Type="Edm.Int32" DefaultValue="0"/>
+
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection>
+            <String>Drafted</String>
+            <String>Engaged</String>
+            <String>Resolved</String>
+            <String>Retired</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Drafted"/>
+        <Annotation Term="Temper.Vocab.ShardKey" String="UserId"/>
+        <Annotation Term="Temper.Vocab.AuthZ.CedarPolicy" String="policies/battle.cedar"/>
+      </EntityType>
+
+      <Action Name="AttestBattleContract" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Battle.Battle"/>
+        <Parameter Name="attestor" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Battle.Battle"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="Engage" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Battle.Battle"/>
+        <Parameter Name="encounter_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Battle.Battle"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Engaged"/>
+      </Action>
+
+      <Action Name="Resolve" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Battle.Battle"/>
+        <Parameter Name="outcome" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Battle.Battle"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Engaged</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Resolved"/>
+      </Action>
+
+      <Action Name="Retire" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Battle.Battle"/>
+        <Parameter Name="successor_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Battle.Battle"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Resolved</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Retired"/>
+      </Action>
+
+      <EntityContainer Name="BattleService">
+        <EntitySet Name="Battles" EntityType="Conducted.Battle.Battle"/>
+      </EntityContainer>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/specs/0001-battle/policies/battle.cedar
+++ b/specs/0001-battle/policies/battle.cedar
@@ -1,0 +1,41 @@
+// spec 0001 - Battle Cedar policy (DESIGN.md §3). Default-deny.
+//
+// The battle engine (BattleEngine) attests the §3 contracts and drives the
+// lifecycle; the player reads their own battle.
+
+permit (
+    principal in [Conducted::BattleEngine],
+    action in [
+        Conducted::Action::"AttestBattleContract"
+    ],
+    resource is Conducted::Battle
+);
+
+permit (
+    principal in [Conducted::BattleEngine],
+    action in [
+        Conducted::Action::"Engage",
+        Conducted::Action::"Resolve",
+        Conducted::Action::"Retire"
+    ],
+    resource is Conducted::Battle
+);
+
+// The player can read their own battle.
+permit (
+    principal is Conducted::User,
+    action == Conducted::Action::"Read",
+    resource is Conducted::Battle
+) when {
+    resource.userId == principal.id
+};
+
+// Terminal-state lockout - IOA invariant RetiredIsTerminal is authoritative;
+// this is defense-in-depth.
+forbid (
+    principal,
+    action,
+    resource is Conducted::Battle
+) when {
+    resource.status == "Retired"
+};

--- a/specs/0002-capture/capture.ioa.toml
+++ b/specs/0002-capture/capture.ioa.toml
@@ -1,0 +1,114 @@
+# spec 0002 - Capture I/O Automaton
+#
+# Models a Boxcar capture attempt against a wild train - thrown, resolved to a
+# single outcome, torn down - per DESIGN.md §4. The active_capture_resolution_count
+# <= 1 invariant formalises "a capture resolves exactly once"; the bools encode
+# the §4 contracts (no trainer capture, captured train never silently lost).
+#
+# Verified by `temper verify -s specs/0002-capture/`.
+
+[automaton]
+name = "Capture"
+states = ["Drafted", "Thrown", "Resolved", "Retired"]
+initial = "Drafted"
+
+# ─────────────────────────── State variables ───────────────────────────
+
+[[state]]
+name = "boxcar_never_captures_trainer_owned_train_per_section_4"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "captured_train_added_to_party_or_explicitly_released_per_section_4"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "captured_train_never_silently_lost_per_section_4"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "gen1_instant_catch_shortcut_honored_per_section_4"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "failed_catch_grants_wild_train_one_free_turn_per_section_4"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "active_capture_resolution_count"
+type = "counter"
+initial = "0"
+
+# ─────────────────────────── Actions ───────────────────────────
+
+[[action]]
+name = "AttestCaptureContract"
+kind = "input"
+from = ["Drafted"]
+params = ["attestor"]
+guard = "is_false failed_catch_grants_wild_train_one_free_turn_per_section_4"
+effect = [
+  { type = "set_bool", var = "boxcar_never_captures_trainer_owned_train_per_section_4", value = true },
+  { type = "set_bool", var = "captured_train_added_to_party_or_explicitly_released_per_section_4", value = true },
+  { type = "set_bool", var = "captured_train_never_silently_lost_per_section_4", value = true },
+  { type = "set_bool", var = "gen1_instant_catch_shortcut_honored_per_section_4", value = true },
+  { type = "set_bool", var = "failed_catch_grants_wild_train_one_free_turn_per_section_4", value = true },
+]
+hint = "Capture engine asserts the §4 contracts before a Boxcar may be thrown."
+
+[[action]]
+name = "Throw"
+kind = "input"
+from = ["Drafted"]
+to = "Thrown"
+params = ["boxcar_id"]
+guard = [
+  { type = "is_true", var = "boxcar_never_captures_trainer_owned_train_per_section_4" },
+  { type = "is_true", var = "captured_train_added_to_party_or_explicitly_released_per_section_4" },
+  { type = "is_true", var = "captured_train_never_silently_lost_per_section_4" },
+  { type = "is_true", var = "gen1_instant_catch_shortcut_honored_per_section_4" },
+  { type = "is_true", var = "failed_catch_grants_wild_train_one_free_turn_per_section_4" },
+]
+hint = "All §4 contracts attested; the Boxcar is thrown at a wild train."
+
+[[action]]
+name = "Resolve"
+kind = "input"
+from = ["Thrown"]
+to = "Resolved"
+params = ["outcome"]
+effect = { type = "increment", var = "active_capture_resolution_count" }
+hint = "Single shake resolution per §4: caught-and-placed OR broke-free (one free enemy turn)."
+
+[[action]]
+name = "Retire"
+kind = "input"
+from = ["Resolved"]
+to = "Retired"
+params = ["successor_id"]
+effect = { type = "decrement", var = "active_capture_resolution_count" }
+hint = "Capture attempt concluded; control returns to the battle/overworld."
+
+# ─────────────────────────── Invariants ───────────────────────────
+
+[[invariant]]
+name = "AtMostOneCaptureResolution"
+assert = "active_capture_resolution_count <= 1"
+
+[[invariant]]
+name = "MustThrowBeforeResolve"
+assert = "ordering(Thrown, Resolved)"
+
+[[invariant]]
+name = "MustResolveBeforeRetire"
+assert = "ordering(Resolved, Retired)"
+
+[[invariant]]
+name = "RetiredIsTerminal"
+when = ["Retired"]
+assert = "no_further_transitions"

--- a/specs/0002-capture/model.csdl.xml
+++ b/specs/0002-capture/model.csdl.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Spec 0002 Capture - CSDL companion to capture.ioa.toml (DESIGN.md §4).
+  Filename MUST be literally `model.csdl.xml`. Mirror every IOA [[state]] as a
+  <Property> and every [[action]] as an <Action>; names must match exactly.
+-->
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+
+    <Schema Namespace="Temper.Vocab" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <Term Name="StateMachine.States" Type="Collection(Edm.String)" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.InitialState" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.ValidFromStates" Type="Collection(Edm.String)" AppliesTo="Action"/>
+      <Term Name="StateMachine.TargetState" Type="Edm.String" AppliesTo="Action"/>
+      <Term Name="Agent.Hint" Type="Edm.String" AppliesTo="Action EntityType"/>
+      <Term Name="ShardKey" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="AuthZ.CedarPolicy" Type="Edm.String" AppliesTo="EntityType Action"/>
+    </Schema>
+
+    <Schema Namespace="Conducted.Capture" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+
+      <EnumType Name="CaptureStatus">
+        <Member Name="Drafted" Value="0"/>
+        <Member Name="Thrown" Value="1"/>
+        <Member Name="Resolved" Value="2"/>
+        <Member Name="Retired" Value="3"/>
+      </EnumType>
+
+      <EntityType Name="Capture">
+        <Key>
+          <PropertyRef Name="CaptureId"/>
+        </Key>
+        <Property Name="CaptureId" Type="Edm.String" Nullable="false"/>
+        <Property Name="UserId" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Conducted.Capture.CaptureStatus" Nullable="false"/>
+
+        <Property Name="boxcar_never_captures_trainer_owned_train_per_section_4" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="captured_train_added_to_party_or_explicitly_released_per_section_4" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="captured_train_never_silently_lost_per_section_4" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="gen1_instant_catch_shortcut_honored_per_section_4" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="failed_catch_grants_wild_train_one_free_turn_per_section_4" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="active_capture_resolution_count" Type="Edm.Int32" DefaultValue="0"/>
+
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection>
+            <String>Drafted</String>
+            <String>Thrown</String>
+            <String>Resolved</String>
+            <String>Retired</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Drafted"/>
+        <Annotation Term="Temper.Vocab.ShardKey" String="UserId"/>
+        <Annotation Term="Temper.Vocab.AuthZ.CedarPolicy" String="policies/capture.cedar"/>
+      </EntityType>
+
+      <Action Name="AttestCaptureContract" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Capture.Capture"/>
+        <Parameter Name="attestor" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Capture.Capture"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="Throw" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Capture.Capture"/>
+        <Parameter Name="boxcar_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Capture.Capture"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Thrown"/>
+      </Action>
+
+      <Action Name="Resolve" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Capture.Capture"/>
+        <Parameter Name="outcome" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Capture.Capture"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Thrown</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Resolved"/>
+      </Action>
+
+      <Action Name="Retire" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Capture.Capture"/>
+        <Parameter Name="successor_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Capture.Capture"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Resolved</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Retired"/>
+      </Action>
+
+      <EntityContainer Name="CaptureService">
+        <EntitySet Name="Captures" EntityType="Conducted.Capture.Capture"/>
+      </EntityContainer>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/specs/0002-capture/policies/capture.cedar
+++ b/specs/0002-capture/policies/capture.cedar
@@ -1,0 +1,41 @@
+// spec 0002 - Capture Cedar policy (DESIGN.md §4). Default-deny.
+//
+// The capture engine (CaptureEngine) attests the §4 contracts and drives the
+// lifecycle; the player reads their own capture attempt.
+
+permit (
+    principal in [Conducted::CaptureEngine],
+    action in [
+        Conducted::Action::"AttestCaptureContract"
+    ],
+    resource is Conducted::Capture
+);
+
+permit (
+    principal in [Conducted::CaptureEngine],
+    action in [
+        Conducted::Action::"Throw",
+        Conducted::Action::"Resolve",
+        Conducted::Action::"Retire"
+    ],
+    resource is Conducted::Capture
+);
+
+// The player can read their own capture attempt.
+permit (
+    principal is Conducted::User,
+    action == Conducted::Action::"Read",
+    resource is Conducted::Capture
+) when {
+    resource.userId == principal.id
+};
+
+// Terminal-state lockout - IOA invariant RetiredIsTerminal is authoritative;
+// this is defense-in-depth.
+forbid (
+    principal,
+    action,
+    resource is Conducted::Capture
+) when {
+    resource.status == "Retired"
+};

--- a/specs/0003-party/model.csdl.xml
+++ b/specs/0003-party/model.csdl.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Spec 0003 Party - CSDL companion to party.ioa.toml (DESIGN.md §5).
+  Filename MUST be literally `model.csdl.xml`. Mirror every IOA [[state]] as a
+  <Property> and every [[action]] as an <Action>; names must match exactly.
+-->
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+
+    <Schema Namespace="Temper.Vocab" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <Term Name="StateMachine.States" Type="Collection(Edm.String)" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.InitialState" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.ValidFromStates" Type="Collection(Edm.String)" AppliesTo="Action"/>
+      <Term Name="StateMachine.TargetState" Type="Edm.String" AppliesTo="Action"/>
+      <Term Name="Agent.Hint" Type="Edm.String" AppliesTo="Action EntityType"/>
+      <Term Name="ShardKey" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="AuthZ.CedarPolicy" Type="Edm.String" AppliesTo="EntityType Action"/>
+    </Schema>
+
+    <Schema Namespace="Conducted.Party" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+
+      <EnumType Name="PartyStatus">
+        <Member Name="Drafted" Value="0"/>
+        <Member Name="Active" Value="1"/>
+        <Member Name="Settled" Value="2"/>
+        <Member Name="Retired" Value="3"/>
+      </EnumType>
+
+      <EntityType Name="Party">
+        <Key>
+          <PropertyRef Name="PartyId"/>
+        </Key>
+        <Property Name="PartyId" Type="Edm.String" Nullable="false"/>
+        <Property Name="UserId" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Conducted.Party.PartyStatus" Nullable="false"/>
+
+        <Property Name="party_size_never_exceeds_six_per_section_5" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="full_party_add_fails_loudly_never_silently_drops_per_section_5" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="heal_restores_full_hp_clears_status_and_revives_per_section_5" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="active_party_mutation_count" Type="Edm.Int32" DefaultValue="0"/>
+
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection>
+            <String>Drafted</String>
+            <String>Active</String>
+            <String>Settled</String>
+            <String>Retired</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Drafted"/>
+        <Annotation Term="Temper.Vocab.ShardKey" String="UserId"/>
+        <Annotation Term="Temper.Vocab.AuthZ.CedarPolicy" String="policies/party.cedar"/>
+      </EntityType>
+
+      <Action Name="AttestPartyContract" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Party.Party"/>
+        <Parameter Name="attestor" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Party.Party"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="Activate" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Party.Party"/>
+        <Parameter Name="party_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Party.Party"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Active"/>
+      </Action>
+
+      <Action Name="Settle" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Party.Party"/>
+        <Parameter Name="mutation_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Party.Party"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Active</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Settled"/>
+      </Action>
+
+      <Action Name="Retire" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Party.Party"/>
+        <Parameter Name="successor_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Party.Party"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Settled</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Retired"/>
+      </Action>
+
+      <EntityContainer Name="PartyService">
+        <EntitySet Name="Partys" EntityType="Conducted.Party.Party"/>
+      </EntityContainer>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/specs/0003-party/party.ioa.toml
+++ b/specs/0003-party/party.ioa.toml
@@ -1,0 +1,100 @@
+# spec 0003 - Party I/O Automaton
+#
+# Models a party mutation (add / heal) - the party becomes active, the mutation
+# settles, it is torn down - per DESIGN.md §5. The active_party_mutation_count
+# <= 1 invariant formalises "one mutation settles at a time"; the bools encode
+# the §5 contracts (bounded size, loud overflow, total heal).
+#
+# Verified by `temper verify -s specs/0003-party/`.
+
+[automaton]
+name = "Party"
+states = ["Drafted", "Active", "Settled", "Retired"]
+initial = "Drafted"
+
+# ─────────────────────────── State variables ───────────────────────────
+
+[[state]]
+name = "party_size_never_exceeds_six_per_section_5"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "full_party_add_fails_loudly_never_silently_drops_per_section_5"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "heal_restores_full_hp_clears_status_and_revives_per_section_5"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "active_party_mutation_count"
+type = "counter"
+initial = "0"
+
+# ─────────────────────────── Actions ───────────────────────────
+
+[[action]]
+name = "AttestPartyContract"
+kind = "input"
+from = ["Drafted"]
+params = ["attestor"]
+guard = "is_false heal_restores_full_hp_clears_status_and_revives_per_section_5"
+effect = [
+  { type = "set_bool", var = "party_size_never_exceeds_six_per_section_5", value = true },
+  { type = "set_bool", var = "full_party_add_fails_loudly_never_silently_drops_per_section_5", value = true },
+  { type = "set_bool", var = "heal_restores_full_hp_clears_status_and_revives_per_section_5", value = true },
+]
+hint = "Party manager asserts the §5 contracts before mutating the party."
+
+[[action]]
+name = "Activate"
+kind = "input"
+from = ["Drafted"]
+to = "Active"
+params = ["party_id"]
+guard = [
+  { type = "is_true", var = "party_size_never_exceeds_six_per_section_5" },
+  { type = "is_true", var = "full_party_add_fails_loudly_never_silently_drops_per_section_5" },
+  { type = "is_true", var = "heal_restores_full_hp_clears_status_and_revives_per_section_5" },
+]
+hint = "All §5 contracts attested; the party is live for a mutation."
+
+[[action]]
+name = "Settle"
+kind = "input"
+from = ["Active"]
+to = "Settled"
+params = ["mutation_id"]
+effect = { type = "increment", var = "active_party_mutation_count" }
+hint = "A single add/heal mutation settles per §5."
+
+[[action]]
+name = "Retire"
+kind = "input"
+from = ["Settled"]
+to = "Retired"
+params = ["successor_id"]
+effect = { type = "decrement", var = "active_party_mutation_count" }
+hint = "Mutation concluded; party returns to rest."
+
+# ─────────────────────────── Invariants ───────────────────────────
+
+[[invariant]]
+name = "AtMostOnePartyMutation"
+assert = "active_party_mutation_count <= 1"
+
+[[invariant]]
+name = "MustActivateBeforeSettle"
+assert = "ordering(Active, Settled)"
+
+[[invariant]]
+name = "MustSettleBeforeRetire"
+assert = "ordering(Settled, Retired)"
+
+[[invariant]]
+name = "RetiredIsTerminal"
+when = ["Retired"]
+assert = "no_further_transitions"

--- a/specs/0003-party/policies/party.cedar
+++ b/specs/0003-party/policies/party.cedar
@@ -1,0 +1,41 @@
+// spec 0003 - Party Cedar policy (DESIGN.md §5). Default-deny.
+//
+// The party manager (PartyManager) attests the §5 contracts and drives the
+// lifecycle; the player reads their own party.
+
+permit (
+    principal in [Conducted::PartyManager],
+    action in [
+        Conducted::Action::"AttestPartyContract"
+    ],
+    resource is Conducted::Party
+);
+
+permit (
+    principal in [Conducted::PartyManager],
+    action in [
+        Conducted::Action::"Activate",
+        Conducted::Action::"Settle",
+        Conducted::Action::"Retire"
+    ],
+    resource is Conducted::Party
+);
+
+// The player can read their own party.
+permit (
+    principal is Conducted::User,
+    action == Conducted::Action::"Read",
+    resource is Conducted::Party
+) when {
+    resource.userId == principal.id
+};
+
+// Terminal-state lockout - IOA invariant RetiredIsTerminal is authoritative;
+// this is defense-in-depth.
+forbid (
+    principal,
+    action,
+    resource is Conducted::Party
+) when {
+    resource.status == "Retired"
+};

--- a/specs/0004-progression/model.csdl.xml
+++ b/specs/0004-progression/model.csdl.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Spec 0004 Progression - CSDL companion to progression.ioa.toml (DESIGN.md §6).
+  Filename MUST be literally `model.csdl.xml`. Mirror every IOA [[state]] as a
+  <Property> and every [[action]] as an <Action>; names must match exactly.
+-->
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+
+    <Schema Namespace="Temper.Vocab" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <Term Name="StateMachine.States" Type="Collection(Edm.String)" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.InitialState" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.ValidFromStates" Type="Collection(Edm.String)" AppliesTo="Action"/>
+      <Term Name="StateMachine.TargetState" Type="Edm.String" AppliesTo="Action"/>
+      <Term Name="Agent.Hint" Type="Edm.String" AppliesTo="Action EntityType"/>
+      <Term Name="ShardKey" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="AuthZ.CedarPolicy" Type="Edm.String" AppliesTo="EntityType Action"/>
+    </Schema>
+
+    <Schema Namespace="Conducted.Progression" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+
+      <EnumType Name="ProgressionStatus">
+        <Member Name="Drafted" Value="0"/>
+        <Member Name="Leveled" Value="1"/>
+        <Member Name="Evolved" Value="2"/>
+        <Member Name="Retired" Value="3"/>
+      </EnumType>
+
+      <EntityType Name="Progression">
+        <Key>
+          <PropertyRef Name="ProgressionId"/>
+        </Key>
+        <Property Name="ProgressionId" Type="Edm.String" Nullable="false"/>
+        <Property Name="UserId" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Conducted.Progression.ProgressionStatus" Nullable="false"/>
+
+        <Property Name="levelup_only_after_exp_past_threshold_capped_at_100_per_section_6" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="evolve_only_when_eligible_level_or_item_method_per_section_6" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="instance_never_mutates_shared_species_template_per_section_6" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="active_evolution_count" Type="Edm.Int32" DefaultValue="0"/>
+
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection>
+            <String>Drafted</String>
+            <String>Leveled</String>
+            <String>Evolved</String>
+            <String>Retired</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Drafted"/>
+        <Annotation Term="Temper.Vocab.ShardKey" String="UserId"/>
+        <Annotation Term="Temper.Vocab.AuthZ.CedarPolicy" String="policies/progression.cedar"/>
+      </EntityType>
+
+      <Action Name="AttestProgressionContract" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Progression.Progression"/>
+        <Parameter Name="attestor" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Progression.Progression"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="LevelUp" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Progression.Progression"/>
+        <Parameter Name="train_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Progression.Progression"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Leveled"/>
+      </Action>
+
+      <Action Name="Evolve" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Progression.Progression"/>
+        <Parameter Name="evolution_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Progression.Progression"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Leveled</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Evolved"/>
+      </Action>
+
+      <Action Name="Retire" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Progression.Progression"/>
+        <Parameter Name="successor_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Progression.Progression"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Evolved</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Retired"/>
+      </Action>
+
+      <EntityContainer Name="ProgressionService">
+        <EntitySet Name="Progressions" EntityType="Conducted.Progression.Progression"/>
+      </EntityContainer>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/specs/0004-progression/policies/progression.cedar
+++ b/specs/0004-progression/policies/progression.cedar
@@ -1,0 +1,41 @@
+// spec 0004 - Progression Cedar policy (DESIGN.md §6). Default-deny.
+//
+// The progression engine (ProgressionEngine) attests the §6 contracts and drives
+// the lifecycle; the player reads their own train's progression.
+
+permit (
+    principal in [Conducted::ProgressionEngine],
+    action in [
+        Conducted::Action::"AttestProgressionContract"
+    ],
+    resource is Conducted::Progression
+);
+
+permit (
+    principal in [Conducted::ProgressionEngine],
+    action in [
+        Conducted::Action::"LevelUp",
+        Conducted::Action::"Evolve",
+        Conducted::Action::"Retire"
+    ],
+    resource is Conducted::Progression
+);
+
+// The player can read their own train's progression.
+permit (
+    principal is Conducted::User,
+    action == Conducted::Action::"Read",
+    resource is Conducted::Progression
+) when {
+    resource.userId == principal.id
+};
+
+// Terminal-state lockout - IOA invariant RetiredIsTerminal is authoritative;
+// this is defense-in-depth.
+forbid (
+    principal,
+    action,
+    resource is Conducted::Progression
+) when {
+    resource.status == "Retired"
+};

--- a/specs/0004-progression/progression.ioa.toml
+++ b/specs/0004-progression/progression.ioa.toml
@@ -1,0 +1,100 @@
+# spec 0004 - Progression I/O Automaton
+#
+# Models a train's progression - it levels up, may evolve, and the change is torn
+# down - per DESIGN.md §6. The active_evolution_count <= 1 invariant formalises
+# "one evolution resolves at a time"; the bools encode the §6 contracts
+# (gain-before-level ordering, evolve-only-when-eligible, instance isolation).
+#
+# Verified by `temper verify -s specs/0004-progression/`.
+
+[automaton]
+name = "Progression"
+states = ["Drafted", "Leveled", "Evolved", "Retired"]
+initial = "Drafted"
+
+# ─────────────────────────── State variables ───────────────────────────
+
+[[state]]
+name = "levelup_only_after_exp_past_threshold_capped_at_100_per_section_6"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "evolve_only_when_eligible_level_or_item_method_per_section_6"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "instance_never_mutates_shared_species_template_per_section_6"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "active_evolution_count"
+type = "counter"
+initial = "0"
+
+# ─────────────────────────── Actions ───────────────────────────
+
+[[action]]
+name = "AttestProgressionContract"
+kind = "input"
+from = ["Drafted"]
+params = ["attestor"]
+guard = "is_false instance_never_mutates_shared_species_template_per_section_6"
+effect = [
+  { type = "set_bool", var = "levelup_only_after_exp_past_threshold_capped_at_100_per_section_6", value = true },
+  { type = "set_bool", var = "evolve_only_when_eligible_level_or_item_method_per_section_6", value = true },
+  { type = "set_bool", var = "instance_never_mutates_shared_species_template_per_section_6", value = true },
+]
+hint = "Progression engine asserts the §6 contracts before applying EXP gains."
+
+[[action]]
+name = "LevelUp"
+kind = "input"
+from = ["Drafted"]
+to = "Leveled"
+params = ["train_id"]
+guard = [
+  { type = "is_true", var = "levelup_only_after_exp_past_threshold_capped_at_100_per_section_6" },
+  { type = "is_true", var = "evolve_only_when_eligible_level_or_item_method_per_section_6" },
+  { type = "is_true", var = "instance_never_mutates_shared_species_template_per_section_6" },
+]
+hint = "All §6 contracts attested; the train levels up past a threshold."
+
+[[action]]
+name = "Evolve"
+kind = "input"
+from = ["Leveled"]
+to = "Evolved"
+params = ["evolution_id"]
+effect = { type = "increment", var = "active_evolution_count" }
+hint = "Eligible evolution fires once per §6, after the level-up that enabled it."
+
+[[action]]
+name = "Retire"
+kind = "input"
+from = ["Evolved"]
+to = "Retired"
+params = ["successor_id"]
+effect = { type = "decrement", var = "active_evolution_count" }
+hint = "Progression change concluded; the train resumes play."
+
+# ─────────────────────────── Invariants ───────────────────────────
+
+[[invariant]]
+name = "AtMostOneEvolution"
+assert = "active_evolution_count <= 1"
+
+[[invariant]]
+name = "MustLevelBeforeEvolve"
+assert = "ordering(Leveled, Evolved)"
+
+[[invariant]]
+name = "MustEvolveBeforeRetire"
+assert = "ordering(Evolved, Retired)"
+
+[[invariant]]
+name = "RetiredIsTerminal"
+when = ["Retired"]
+assert = "no_further_transitions"

--- a/specs/0005-save-load/model.csdl.xml
+++ b/specs/0005-save-load/model.csdl.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Spec 0005 SaveLoad - CSDL companion to save-load.ioa.toml (DESIGN.md §7).
+  Filename MUST be literally `model.csdl.xml`. Mirror every IOA [[state]] as a
+  <Property> and every [[action]] as an <Action>; names must match exactly.
+-->
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+
+    <Schema Namespace="Temper.Vocab" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <Term Name="StateMachine.States" Type="Collection(Edm.String)" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.InitialState" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.ValidFromStates" Type="Collection(Edm.String)" AppliesTo="Action"/>
+      <Term Name="StateMachine.TargetState" Type="Edm.String" AppliesTo="Action"/>
+      <Term Name="Agent.Hint" Type="Edm.String" AppliesTo="Action EntityType"/>
+      <Term Name="ShardKey" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="AuthZ.CedarPolicy" Type="Edm.String" AppliesTo="EntityType Action"/>
+    </Schema>
+
+    <Schema Namespace="Conducted.SaveLoad" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+
+      <EnumType Name="SaveLoadStatus">
+        <Member Name="Drafted" Value="0"/>
+        <Member Name="Saved" Value="1"/>
+        <Member Name="Loaded" Value="2"/>
+        <Member Name="Retired" Value="3"/>
+      </EnumType>
+
+      <EntityType Name="SaveLoad">
+        <Key>
+          <PropertyRef Name="SaveLoadId"/>
+        </Key>
+        <Property Name="SaveLoadId" Type="Edm.String" Nullable="false"/>
+        <Property Name="UserId" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Conducted.SaveLoad.SaveLoadStatus" Nullable="false"/>
+
+        <Property Name="save_load_delegate_to_player_codec_single_schema_per_section_7" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="roundtrip_preserves_badges_story_flags_party_items_money_per_section_7" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="transient_run_state_not_persisted_version_carried_per_section_7" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="active_load_count" Type="Edm.Int32" DefaultValue="0"/>
+
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection>
+            <String>Drafted</String>
+            <String>Saved</String>
+            <String>Loaded</String>
+            <String>Retired</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Drafted"/>
+        <Annotation Term="Temper.Vocab.ShardKey" String="UserId"/>
+        <Annotation Term="Temper.Vocab.AuthZ.CedarPolicy" String="policies/save-load.cedar"/>
+      </EntityType>
+
+      <Action Name="AttestSaveLoadContract" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.SaveLoad.SaveLoad"/>
+        <Parameter Name="attestor" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.SaveLoad.SaveLoad"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="Save" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.SaveLoad.SaveLoad"/>
+        <Parameter Name="save_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.SaveLoad.SaveLoad"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Saved"/>
+      </Action>
+
+      <Action Name="Load" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.SaveLoad.SaveLoad"/>
+        <Parameter Name="load_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.SaveLoad.SaveLoad"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Saved</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Loaded"/>
+      </Action>
+
+      <Action Name="Retire" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.SaveLoad.SaveLoad"/>
+        <Parameter Name="successor_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.SaveLoad.SaveLoad"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Loaded</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Retired"/>
+      </Action>
+
+      <EntityContainer Name="SaveLoadService">
+        <EntitySet Name="SaveLoads" EntityType="Conducted.SaveLoad.SaveLoad"/>
+      </EntityContainer>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/specs/0005-save-load/policies/save-load.cedar
+++ b/specs/0005-save-load/policies/save-load.cedar
@@ -1,0 +1,41 @@
+// spec 0005 - SaveLoad Cedar policy (DESIGN.md §7). Default-deny.
+//
+// The save manager (SaveManager) attests the §7 contracts and drives the
+// save/load lifecycle; the player reads their own save.
+
+permit (
+    principal in [Conducted::SaveManager],
+    action in [
+        Conducted::Action::"AttestSaveLoadContract"
+    ],
+    resource is Conducted::SaveLoad
+);
+
+permit (
+    principal in [Conducted::SaveManager],
+    action in [
+        Conducted::Action::"Save",
+        Conducted::Action::"Load",
+        Conducted::Action::"Retire"
+    ],
+    resource is Conducted::SaveLoad
+);
+
+// The player can read their own save.
+permit (
+    principal is Conducted::User,
+    action == Conducted::Action::"Read",
+    resource is Conducted::SaveLoad
+) when {
+    resource.userId == principal.id
+};
+
+// Terminal-state lockout - IOA invariant RetiredIsTerminal is authoritative;
+// this is defense-in-depth.
+forbid (
+    principal,
+    action,
+    resource is Conducted::SaveLoad
+) when {
+    resource.status == "Retired"
+};

--- a/specs/0005-save-load/save-load.ioa.toml
+++ b/specs/0005-save-load/save-load.ioa.toml
@@ -1,0 +1,100 @@
+# spec 0005 - SaveLoad I/O Automaton
+#
+# Models a persistence round trip - state is saved, later loaded, the cycle torn
+# down - per DESIGN.md §7. The active_load_count <= 1 invariant formalises "one
+# load is applied at a time"; the bools encode the §7 contracts (single codec,
+# round-trip preserves progress, no transient state persisted).
+#
+# Verified by `temper verify -s specs/0005-save-load/`.
+
+[automaton]
+name = "SaveLoad"
+states = ["Drafted", "Saved", "Loaded", "Retired"]
+initial = "Drafted"
+
+# ─────────────────────────── State variables ───────────────────────────
+
+[[state]]
+name = "save_load_delegate_to_player_codec_single_schema_per_section_7"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "roundtrip_preserves_badges_story_flags_party_items_money_per_section_7"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "transient_run_state_not_persisted_version_carried_per_section_7"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "active_load_count"
+type = "counter"
+initial = "0"
+
+# ─────────────────────────── Actions ───────────────────────────
+
+[[action]]
+name = "AttestSaveLoadContract"
+kind = "input"
+from = ["Drafted"]
+params = ["attestor"]
+guard = "is_false transient_run_state_not_persisted_version_carried_per_section_7"
+effect = [
+  { type = "set_bool", var = "save_load_delegate_to_player_codec_single_schema_per_section_7", value = true },
+  { type = "set_bool", var = "roundtrip_preserves_badges_story_flags_party_items_money_per_section_7", value = true },
+  { type = "set_bool", var = "transient_run_state_not_persisted_version_carried_per_section_7", value = true },
+]
+hint = "Save manager asserts the §7 contracts before serializing player state."
+
+[[action]]
+name = "Save"
+kind = "input"
+from = ["Drafted"]
+to = "Saved"
+params = ["save_id"]
+guard = [
+  { type = "is_true", var = "save_load_delegate_to_player_codec_single_schema_per_section_7" },
+  { type = "is_true", var = "roundtrip_preserves_badges_story_flags_party_items_money_per_section_7" },
+  { type = "is_true", var = "transient_run_state_not_persisted_version_carried_per_section_7" },
+]
+hint = "All §7 contracts attested; Player.toJSON writes the single-schema save."
+
+[[action]]
+name = "Load"
+kind = "input"
+from = ["Saved"]
+to = "Loaded"
+params = ["load_id"]
+effect = { type = "increment", var = "active_load_count" }
+hint = "Player.fromJSON applies one load, preserving badges/story flags per §7."
+
+[[action]]
+name = "Retire"
+kind = "input"
+from = ["Loaded"]
+to = "Retired"
+params = ["successor_id"]
+effect = { type = "decrement", var = "active_load_count" }
+hint = "Round trip concluded; gameplay resumes from the restored state."
+
+# ─────────────────────────── Invariants ───────────────────────────
+
+[[invariant]]
+name = "AtMostOneLoad"
+assert = "active_load_count <= 1"
+
+[[invariant]]
+name = "MustSaveBeforeLoad"
+assert = "ordering(Saved, Loaded)"
+
+[[invariant]]
+name = "MustLoadBeforeRetire"
+assert = "ordering(Loaded, Retired)"
+
+[[invariant]]
+name = "RetiredIsTerminal"
+when = ["Retired"]
+assert = "no_further_transitions"

--- a/specs/0006-map-warp/map-warp.ioa.toml
+++ b/specs/0006-map-warp/map-warp.ioa.toml
@@ -1,0 +1,100 @@
+# spec 0006 - MapWarp I/O Automaton
+#
+# Models a map-to-map warp - the player enters a warp tile, arrives on the
+# destination, the transition is torn down - per DESIGN.md §8. The
+# active_warp_count <= 1 invariant formalises "one warp resolves at a time"; the
+# bools encode the §8 contracts (destination registered, walkable, re-entry safe).
+#
+# Verified by `temper verify -s specs/0006-map-warp/`.
+
+[automaton]
+name = "MapWarp"
+states = ["Drafted", "Entered", "Arrived", "Retired"]
+initial = "Drafted"
+
+# ─────────────────────────── State variables ───────────────────────────
+
+[[state]]
+name = "warp_fires_only_if_destination_map_registered_per_section_8"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "warp_destination_tile_is_walkable_per_section_8"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "warp_endpoints_paired_and_reentry_safe_no_pingpong_per_section_8"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "active_warp_count"
+type = "counter"
+initial = "0"
+
+# ─────────────────────────── Actions ───────────────────────────
+
+[[action]]
+name = "AttestMapWarpContract"
+kind = "input"
+from = ["Drafted"]
+params = ["attestor"]
+guard = "is_false warp_endpoints_paired_and_reentry_safe_no_pingpong_per_section_8"
+effect = [
+  { type = "set_bool", var = "warp_fires_only_if_destination_map_registered_per_section_8", value = true },
+  { type = "set_bool", var = "warp_destination_tile_is_walkable_per_section_8", value = true },
+  { type = "set_bool", var = "warp_endpoints_paired_and_reentry_safe_no_pingpong_per_section_8", value = true },
+]
+hint = "Warp controller asserts the §8 contracts before any warp may fire."
+
+[[action]]
+name = "Enter"
+kind = "input"
+from = ["Drafted"]
+to = "Entered"
+params = ["warp_id"]
+guard = [
+  { type = "is_true", var = "warp_fires_only_if_destination_map_registered_per_section_8" },
+  { type = "is_true", var = "warp_destination_tile_is_walkable_per_section_8" },
+  { type = "is_true", var = "warp_endpoints_paired_and_reentry_safe_no_pingpong_per_section_8" },
+]
+hint = "All §8 contracts attested; the player steps onto a valid warp tile."
+
+[[action]]
+name = "Arrive"
+kind = "input"
+from = ["Entered"]
+to = "Arrived"
+params = ["destination_id"]
+effect = { type = "increment", var = "active_warp_count" }
+hint = "Player placed on the registered, walkable destination tile per §8."
+
+[[action]]
+name = "Retire"
+kind = "input"
+from = ["Arrived"]
+to = "Retired"
+params = ["successor_id"]
+effect = { type = "decrement", var = "active_warp_count" }
+hint = "Warp concluded; the re-entry guard prevents an immediate reciprocal warp."
+
+# ─────────────────────────── Invariants ───────────────────────────
+
+[[invariant]]
+name = "AtMostOneWarp"
+assert = "active_warp_count <= 1"
+
+[[invariant]]
+name = "MustEnterBeforeArrive"
+assert = "ordering(Entered, Arrived)"
+
+[[invariant]]
+name = "MustArriveBeforeRetire"
+assert = "ordering(Arrived, Retired)"
+
+[[invariant]]
+name = "RetiredIsTerminal"
+when = ["Retired"]
+assert = "no_further_transitions"

--- a/specs/0006-map-warp/model.csdl.xml
+++ b/specs/0006-map-warp/model.csdl.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Spec 0006 MapWarp - CSDL companion to map-warp.ioa.toml (DESIGN.md §8).
+  Filename MUST be literally `model.csdl.xml`. Mirror every IOA [[state]] as a
+  <Property> and every [[action]] as an <Action>; names must match exactly.
+-->
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+
+    <Schema Namespace="Temper.Vocab" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <Term Name="StateMachine.States" Type="Collection(Edm.String)" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.InitialState" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.ValidFromStates" Type="Collection(Edm.String)" AppliesTo="Action"/>
+      <Term Name="StateMachine.TargetState" Type="Edm.String" AppliesTo="Action"/>
+      <Term Name="Agent.Hint" Type="Edm.String" AppliesTo="Action EntityType"/>
+      <Term Name="ShardKey" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="AuthZ.CedarPolicy" Type="Edm.String" AppliesTo="EntityType Action"/>
+    </Schema>
+
+    <Schema Namespace="Conducted.MapWarp" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+
+      <EnumType Name="MapWarpStatus">
+        <Member Name="Drafted" Value="0"/>
+        <Member Name="Entered" Value="1"/>
+        <Member Name="Arrived" Value="2"/>
+        <Member Name="Retired" Value="3"/>
+      </EnumType>
+
+      <EntityType Name="MapWarp">
+        <Key>
+          <PropertyRef Name="MapWarpId"/>
+        </Key>
+        <Property Name="MapWarpId" Type="Edm.String" Nullable="false"/>
+        <Property Name="UserId" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Conducted.MapWarp.MapWarpStatus" Nullable="false"/>
+
+        <Property Name="warp_fires_only_if_destination_map_registered_per_section_8" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="warp_destination_tile_is_walkable_per_section_8" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="warp_endpoints_paired_and_reentry_safe_no_pingpong_per_section_8" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="active_warp_count" Type="Edm.Int32" DefaultValue="0"/>
+
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection>
+            <String>Drafted</String>
+            <String>Entered</String>
+            <String>Arrived</String>
+            <String>Retired</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Drafted"/>
+        <Annotation Term="Temper.Vocab.ShardKey" String="UserId"/>
+        <Annotation Term="Temper.Vocab.AuthZ.CedarPolicy" String="policies/map-warp.cedar"/>
+      </EntityType>
+
+      <Action Name="AttestMapWarpContract" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.MapWarp.MapWarp"/>
+        <Parameter Name="attestor" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.MapWarp.MapWarp"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="Enter" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.MapWarp.MapWarp"/>
+        <Parameter Name="warp_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.MapWarp.MapWarp"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Entered"/>
+      </Action>
+
+      <Action Name="Arrive" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.MapWarp.MapWarp"/>
+        <Parameter Name="destination_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.MapWarp.MapWarp"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Entered</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Arrived"/>
+      </Action>
+
+      <Action Name="Retire" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.MapWarp.MapWarp"/>
+        <Parameter Name="successor_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.MapWarp.MapWarp"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Arrived</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Retired"/>
+      </Action>
+
+      <EntityContainer Name="MapWarpService">
+        <EntitySet Name="MapWarps" EntityType="Conducted.MapWarp.MapWarp"/>
+      </EntityContainer>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/specs/0006-map-warp/policies/map-warp.cedar
+++ b/specs/0006-map-warp/policies/map-warp.cedar
@@ -1,0 +1,41 @@
+// spec 0006 - MapWarp Cedar policy (DESIGN.md §8). Default-deny.
+//
+// The warp controller (WarpController) attests the §8 contracts and drives the
+// warp lifecycle; the player reads their own warp transition.
+
+permit (
+    principal in [Conducted::WarpController],
+    action in [
+        Conducted::Action::"AttestMapWarpContract"
+    ],
+    resource is Conducted::MapWarp
+);
+
+permit (
+    principal in [Conducted::WarpController],
+    action in [
+        Conducted::Action::"Enter",
+        Conducted::Action::"Arrive",
+        Conducted::Action::"Retire"
+    ],
+    resource is Conducted::MapWarp
+);
+
+// The player can read their own warp transition.
+permit (
+    principal is Conducted::User,
+    action == Conducted::Action::"Read",
+    resource is Conducted::MapWarp
+) when {
+    resource.userId == principal.id
+};
+
+// Terminal-state lockout - IOA invariant RetiredIsTerminal is authoritative;
+// this is defense-in-depth.
+forbid (
+    principal,
+    action,
+    resource is Conducted::MapWarp
+) when {
+    resource.status == "Retired"
+};

--- a/specs/0007-economy/economy.ioa.toml
+++ b/specs/0007-economy/economy.ioa.toml
@@ -1,0 +1,101 @@
+# spec 0007 - Economy I/O Automaton
+#
+# Models a shop purchase - an item is priced, the purchase settles (committed or
+# refused), the transaction is torn down - per DESIGN.md §9. The
+# active_purchase_count <= 1 invariant formalises "one purchase settles at a
+# time"; the bools encode the §9 contracts (single spend gate, atomic purchase,
+# data-driven catalog).
+#
+# Verified by `temper verify -s specs/0007-economy/`.
+
+[automaton]
+name = "Economy"
+states = ["Drafted", "Priced", "Settled", "Retired"]
+initial = "Drafted"
+
+# ─────────────────────────── State variables ───────────────────────────
+
+[[state]]
+name = "all_spending_through_spendmoney_never_negative_per_section_9"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "purchase_atomic_deduct_and_grant_or_neither_per_section_9"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "shop_catalog_derived_from_items_registry_per_section_9"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "active_purchase_count"
+type = "counter"
+initial = "0"
+
+# ─────────────────────────── Actions ───────────────────────────
+
+[[action]]
+name = "AttestEconomyContract"
+kind = "input"
+from = ["Drafted"]
+params = ["attestor"]
+guard = "is_false shop_catalog_derived_from_items_registry_per_section_9"
+effect = [
+  { type = "set_bool", var = "all_spending_through_spendmoney_never_negative_per_section_9", value = true },
+  { type = "set_bool", var = "purchase_atomic_deduct_and_grant_or_neither_per_section_9", value = true },
+  { type = "set_bool", var = "shop_catalog_derived_from_items_registry_per_section_9", value = true },
+]
+hint = "Shop manager asserts the §9 contracts before any purchase may be priced."
+
+[[action]]
+name = "Price"
+kind = "input"
+from = ["Drafted"]
+to = "Priced"
+params = ["item_id"]
+guard = [
+  { type = "is_true", var = "all_spending_through_spendmoney_never_negative_per_section_9" },
+  { type = "is_true", var = "purchase_atomic_deduct_and_grant_or_neither_per_section_9" },
+  { type = "is_true", var = "shop_catalog_derived_from_items_registry_per_section_9" },
+]
+hint = "All §9 contracts attested; the item price is quoted from the Items registry."
+
+[[action]]
+name = "Settle"
+kind = "input"
+from = ["Priced"]
+to = "Settled"
+params = ["transaction_id"]
+effect = { type = "increment", var = "active_purchase_count" }
+hint = "spendMoney commits atomically (deduct + grant) or refuses, per §9."
+
+[[action]]
+name = "Retire"
+kind = "input"
+from = ["Settled"]
+to = "Retired"
+params = ["successor_id"]
+effect = { type = "decrement", var = "active_purchase_count" }
+hint = "Transaction concluded; the player returns to the shop menu."
+
+# ─────────────────────────── Invariants ───────────────────────────
+
+[[invariant]]
+name = "AtMostOnePurchase"
+assert = "active_purchase_count <= 1"
+
+[[invariant]]
+name = "MustPriceBeforeSettle"
+assert = "ordering(Priced, Settled)"
+
+[[invariant]]
+name = "MustSettleBeforeRetire"
+assert = "ordering(Settled, Retired)"
+
+[[invariant]]
+name = "RetiredIsTerminal"
+when = ["Retired"]
+assert = "no_further_transitions"

--- a/specs/0007-economy/model.csdl.xml
+++ b/specs/0007-economy/model.csdl.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Spec 0007 Economy - CSDL companion to economy.ioa.toml (DESIGN.md §9).
+  Filename MUST be literally `model.csdl.xml`. Mirror every IOA [[state]] as a
+  <Property> and every [[action]] as an <Action>; names must match exactly.
+-->
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+
+    <Schema Namespace="Temper.Vocab" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <Term Name="StateMachine.States" Type="Collection(Edm.String)" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.InitialState" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.ValidFromStates" Type="Collection(Edm.String)" AppliesTo="Action"/>
+      <Term Name="StateMachine.TargetState" Type="Edm.String" AppliesTo="Action"/>
+      <Term Name="Agent.Hint" Type="Edm.String" AppliesTo="Action EntityType"/>
+      <Term Name="ShardKey" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="AuthZ.CedarPolicy" Type="Edm.String" AppliesTo="EntityType Action"/>
+    </Schema>
+
+    <Schema Namespace="Conducted.Economy" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+
+      <EnumType Name="EconomyStatus">
+        <Member Name="Drafted" Value="0"/>
+        <Member Name="Priced" Value="1"/>
+        <Member Name="Settled" Value="2"/>
+        <Member Name="Retired" Value="3"/>
+      </EnumType>
+
+      <EntityType Name="Economy">
+        <Key>
+          <PropertyRef Name="EconomyId"/>
+        </Key>
+        <Property Name="EconomyId" Type="Edm.String" Nullable="false"/>
+        <Property Name="UserId" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Conducted.Economy.EconomyStatus" Nullable="false"/>
+
+        <Property Name="all_spending_through_spendmoney_never_negative_per_section_9" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="purchase_atomic_deduct_and_grant_or_neither_per_section_9" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="shop_catalog_derived_from_items_registry_per_section_9" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="active_purchase_count" Type="Edm.Int32" DefaultValue="0"/>
+
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection>
+            <String>Drafted</String>
+            <String>Priced</String>
+            <String>Settled</String>
+            <String>Retired</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="Drafted"/>
+        <Annotation Term="Temper.Vocab.ShardKey" String="UserId"/>
+        <Annotation Term="Temper.Vocab.AuthZ.CedarPolicy" String="policies/economy.cedar"/>
+      </EntityType>
+
+      <Action Name="AttestEconomyContract" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Economy.Economy"/>
+        <Parameter Name="attestor" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Economy.Economy"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+      </Action>
+
+      <Action Name="Price" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Economy.Economy"/>
+        <Parameter Name="item_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Economy.Economy"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Drafted</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Priced"/>
+      </Action>
+
+      <Action Name="Settle" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Economy.Economy"/>
+        <Parameter Name="transaction_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Economy.Economy"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Priced</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Settled"/>
+      </Action>
+
+      <Action Name="Retire" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Conducted.Economy.Economy"/>
+        <Parameter Name="successor_id" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Conducted.Economy.Economy"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates">
+          <Collection><String>Settled</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Retired"/>
+      </Action>
+
+      <EntityContainer Name="EconomyService">
+        <EntitySet Name="Economys" EntityType="Conducted.Economy.Economy"/>
+      </EntityContainer>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/specs/0007-economy/policies/economy.cedar
+++ b/specs/0007-economy/policies/economy.cedar
@@ -1,0 +1,41 @@
+// spec 0007 - Economy Cedar policy (DESIGN.md §9). Default-deny.
+//
+// The shop manager (ShopManager) attests the §9 contracts and drives the
+// purchase lifecycle; the player reads their own transaction.
+
+permit (
+    principal in [Conducted::ShopManager],
+    action in [
+        Conducted::Action::"AttestEconomyContract"
+    ],
+    resource is Conducted::Economy
+);
+
+permit (
+    principal in [Conducted::ShopManager],
+    action in [
+        Conducted::Action::"Price",
+        Conducted::Action::"Settle",
+        Conducted::Action::"Retire"
+    ],
+    resource is Conducted::Economy
+);
+
+// The player can read their own transaction.
+permit (
+    principal is Conducted::User,
+    action == Conducted::Action::"Read",
+    resource is Conducted::Economy
+) when {
+    resource.userId == principal.id
+};
+
+// Terminal-state lockout - IOA invariant RetiredIsTerminal is authoritative;
+// this is defense-in-depth.
+forbid (
+    principal,
+    action,
+    resource is Conducted::Economy
+) when {
+    resource.status == "Retired"
+};

--- a/specs/DESIGN.md
+++ b/specs/DESIGN.md
@@ -1,0 +1,166 @@
+# Conducted - Game Systems Design (Spec Source of Truth)
+
+This is the authoritative contract document for the Conducted core game systems.
+Every temper IOA spec under `specs/NNNN-*/` cites a section number (`§N`) here in
+its action `hint`s. If code and this doc disagree, align code to the doc (or
+amend the doc in the same change and note why).
+
+Narrative/world/art truth lives in `WORLDBUILDING.md`, `STORY.md`, and
+`ART_DIRECTION_SPECS.md`. This doc governs *behavioural* contracts only.
+
+The contracts below were derived from the post-audit core-systems rewrite; each
+encodes a bug class that was found and fixed, so the spec layer guards against
+regression.
+
+---
+
+## §1 Overview
+
+Conducted is a browser, Canvas-2D, no-framework Pokemon-style RPG where the
+player captures, trains, and battles trains. State is held in plain objects;
+persistence is `localStorage`. There is no server.
+
+Core entities with kernel-verified contracts:
+
+- §3 Battle lifecycle  -> `0001-battle`
+- §4 Capture           -> `0002-capture`
+- §5 Party             -> `0003-party`
+- §6 Progression       -> `0004-progression`
+- §7 Save / Load       -> `0005-save-load`
+- §8 Map / Warp        -> `0006-map-warp`
+- §9 Economy / Shop    -> `0007-economy`
+
+---
+
+## §2 Top-level game state machine
+
+`title -> intro -> starter_selection -> overworld -> {battle | menu | dialogue}`.
+
+- A returning player with a save and a non-empty party resumes from `title`
+  straight to `overworld` (the transient run-state is NOT persisted; §7).
+- Every state transition clears one-shot "just pressed" input so a key buffered
+  during one state cannot auto-trigger an action in the next.
+
+---
+
+## §3 Battle lifecycle
+
+A battle is created, runs zero or more turns, resolves exactly once, and is then
+torn down. Contracts:
+
+1. **Single end-of-battle owner.** Exactly ONE code path resolves the end of a
+   battle (`checkBattleEnd`). Victory/defeat handlers are idempotent. At most one
+   end-of-battle resolution may be in flight at any time. (Fixes the double-EXP /
+   double-badge race.)
+2. **Turn order by effective speed + priority.** The acting order of a turn is
+   determined by move priority first, then status-adjusted effective speed
+   (paralysis quarters speed), ties broken randomly. The player does NOT always
+   act first.
+3. **Damage computed at resolution time.** A move's damage is computed when it
+   resolves, against the then-current state - not when the move is selected.
+4. **Faint interrupts the turn.** When a train faints mid-turn, remaining queued
+   actions for that turn do not execute; resolution passes to the single owner.
+5. **EXP awarded once per defeated enemy.** Each defeated enemy grants EXP to the
+   active train exactly once, before the next enemy (if any) is sent out.
+
+Lifecycle: `Drafted -> Engaged -> Resolved -> Retired`. `Resolved` is reached at
+most once; `Retired` is terminal and returns control to the overworld.
+
+---
+
+## §4 Capture
+
+Throwing a Boxcar at a WILD train may capture it (Gen-1 style shake formula).
+Contracts:
+
+1. **No trainer capture.** A Boxcar can never capture a trainer-owned train.
+2. **Captured trains are never lost.** A successfully captured train is always
+   added to the party, or (if the party is full) explicitly released with a
+   message - it never silently vanishes. (Fixes the inert-capture bug where the
+   caught train was recorded but never read.)
+3. **Guaranteed-catch shortcut.** Catch math honours the Gen-1 instant-catch
+   case; a failed catch grants the wild train one free turn.
+
+Lifecycle: `Drafted -> Thrown -> Resolved -> Retired`. `Resolved` records the
+single outcome (caught-and-placed OR broke-free).
+
+---
+
+## §5 Party
+
+The player's party of trains. Contracts:
+
+1. **Bounded size.** The party never exceeds 6 trains.
+2. **Overflow is explicit.** Adding to a full party fails loudly (caller handles
+   box/release), never silently drops the train.
+3. **Heal is total.** Healing the party restores full HP AND clears status AND
+   revives fainted trains, via a single canonical method.
+
+Lifecycle: `Drafted -> Active -> Full -> Retired` (Full = at the 6 cap).
+
+---
+
+## §6 Progression
+
+A train gains EXP, levels up, and may evolve. Contracts:
+
+1. **Gain-before-level ordering.** A level-up only occurs after EXP is gained
+   past the next threshold; level is capped at 100.
+2. **Evolve only when eligible.** Evolution fires only when `canEvolve` holds:
+   level-method at/after the threshold level, or item-method with the matching
+   item. Evolution happens after the level-up that made it eligible.
+3. **Instance isolation.** A train instance never mutates its shared species
+   template (type arrays are cloned), so evolving/altering one train cannot
+   corrupt other trains of the same species.
+
+Lifecycle: `Drafted -> Leveled -> Evolved -> Retired`.
+
+---
+
+## §7 Save / Load
+
+Persistence to `localStorage`. Contracts:
+
+1. **Single serialization owner.** Save/load delegate to `Player.toJSON` /
+   `Player.fromJSON` - the one schema. No hand-rolled divergent copy. (Fixes the
+   bug where badges + story flags were silently dropped on load.)
+2. **Round-trip preserves progress.** Badges, badge count, story flags
+   (`metProfessor`, `defeatedGymLeaders`), party (with IVs), items, and money
+   survive a save -> load round trip.
+3. **No transient state persisted.** The run-state (title/battle/menu) is not
+   saved; the title screen decides whether to resume (§2). A save carries a
+   `version` for future migration.
+
+Lifecycle: `Drafted -> Saved -> Loaded -> Retired`.
+
+---
+
+## §8 Map / Warp transitions
+
+Overworld movement and map-to-map warps. Contracts:
+
+1. **Warps resolve to a real map.** A warp only fires if its destination map is
+   registered; an unknown destination is refused (never strands the player).
+2. **Never warp into a wall.** A warp destination tile is walkable.
+3. **Reciprocal, re-entry-safe.** Warp endpoints are paired, and stepping onto a
+   destination tile does not immediately re-trigger the reciprocal warp
+   (no ping-pong).
+
+Lifecycle: `Drafted -> Entered -> Arrived -> Retired` (Arrived = on the
+destination map at the destination tile).
+
+---
+
+## §9 Economy / Shop
+
+Money and the mart. Contracts:
+
+1. **Single spend gate.** All spending goes through `Player.spendMoney`, which
+   refuses if unaffordable; money can never go negative.
+2. **Atomic purchase.** A purchase either deducts the price AND grants the item,
+   or does neither.
+3. **Catalog is data.** The shop catalog is derived from the single Items
+   registry, not hardcoded per call site.
+
+Lifecycle: `Drafted -> Priced -> Settled -> Retired` (Settled = purchase
+committed or refused).


### PR DESCRIPTION
## Why

A full code audit of Conducted found the core M1 systems were broken in normal
play: captured trains vanished, evolution never fired, saves silently wiped
badges + story flags, battles double-resolved (double EXP / re-earned badges),
turn order ignored speed, and trainer battles + bag-potion use threw on entry.
The game also rendered with placeholder art ("looks horrific").

This PR (1) rewrites those systems and fixes the bugs, (2) bootstraps the repo
onto the temper SDD kernel so the contracts are formally verified and can't
regress, and (3) modernizes the renderer to a GBC-era Pokemon look in-engine.

## What changed

Core (audit fixes):
- Battle: one idempotent end-of-battle owner (checkBattleEnd) removes the
  double-resolution race; speed + move-priority turn order; damage computed at
  resolution time; status effects implemented (paralyze/burn/poison/flinch/
  recoil/multi-hit/stat-stages); benched-train switch.
- Capture is wired into victory (caught train added to party, or released if
  full) - it was recorded but never read.
- Evolution fires on level-up; Train clones its species template arrays (no
  cross-instance corruption); item-evolution branch implemented.
- Save/load delegates to Player.toJSON/fromJSON (single schema; badges + story
  flags preserved), adds a version field, stops persisting transient run-state.
- Blackout respawns on the correct map key (was stranding the player and
  halving money every frame).
- Crash fixes: trainer-battle entry (TRAIN_DATA/Train ctor), bag-potion use
  (train.stats.hp -> train.maxHP, 3 sites incl. party-menu render).
- Deterministic procedural species (seeded PRNG) so a saved train deserializes
  identically next session.
- New js/items.js: single source of truth for shop/bag/battle item data.
- Resilient game loop (re-schedules on throw); per-frame input reset (no
  phantom inputs across state transitions).

SDD layer (temper):
- specs/DESIGN.md + 7 IOA specs (battle, capture, party, progression,
  save-load, map-warp, economy), namespace Conducted.
- .github/workflows/check.temper-specs.yml verifies every spec on PRs touching
  specs/**.

Visual:
- Cohesive palette, framed battle HUD with type chips + HP bars, stylized
  procedural locomotive art, polished title/loading screens, directional
  player + role-colored NPC sprites, debug overlay gated off.

## Acceptance criteria

- The wild-battle loop resolves exactly once (no double EXP / double badge).
- A captured wild train ends up in the party (or is explicitly released).
- A save -> load round trip preserves badges, story flags, party, items, money.
- Trainer battles and bag-potion use no longer throw.
- All 7 temper specs pass the L0-L3 cascade and gate CI.
- The game boots and renders the modernized battle/overworld with 0 console errors.

## Test plan

Verified in a headless browser (Playwright) at 0 real console errors:
- Boot -> title -> intro -> starter -> overworld; save resumes to overworld.
- Wild battle resolves exactly once (victoryCalls == 1), no double EXP.
- Capture adds the wild train to the party (1 -> 2).
- Save/load preserves badges (Coal Badge) + metProfessor across a round trip.
- Trainer battle starts with 3 enemies, no crash.
- Field bag potion heals (HP 1 -> 21), no crash.
- Turn order picks the faster train first; staged stats drive damage; status
  applies; species template not mutated by an instance.
- Procedural species byte-identical across reload.
- Battle render does not throw after the visual overhaul.

Spec layer: 7/7 specs PASS L0 (Z3 symbolic) + L1 (model check) + L2 (sim) +
L3 (property tests), SHA-locked to the workflow. Static: node --check clean on
every JS file.

## Size

Size: L

Milestone-level batch (core rewrite + SDD bootstrap + visual overhaul), beyond
the usual small-PR norm because the work is intertwined across the same files
and was driven as one effort. Happy to split into stacked PRs (core fixes /
visual / SDD) if preferred before merge.

## Out of scope (follow-ups)

- #52 map-transition rewrite: divergent walkability schemes + warps to
  undefined interior maps (PlayerHouse/TrainMart/HealingDepot) still freeze on
  the door. The 0006-map-warp spec contract is authored and waiting for the
  implementation to satisfy it.
- Intro screen still renders plain text (didn't get the title-screen polish).
- GPU/Spark asset pipeline: the baked overworld tileset PNG (harsh green) and
  real per-species battle sprites (only 3 starters exist) need regeneration;
  in-engine work covers everything else.
- No exhaustive 30-60 min manual playthrough yet; behaviour verified via
  scripted logic tests + screenshots.

## Related issues

Refs #56 (white-out/respawn), #50 (evolution), #48 (level-up/progression),
#69 (Rail Mart shop), #58 (run/flee), #54 (starter selection), #47 (battle
visuals), #52 (map transitions - contract added, impl deferred).
