### PR TITLE
chore: update githumps references to quadseven (account rename)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,7 +5,7 @@
 CONDUCTED = Browser-based train battle RPG (Pokémon Red/Blue feel, but with original trains).
 - Pure JS + Canvas, no framework, mobile-optimized
 - Repo: /Users/evan/Documents/GitHub/conducted
-- Live: https://githumps.github.io/conducted/
+- Live: https://quadseven.github.io/conducted/
 - Status: Milestone 1 (M1) → MVP rebuild in progress
 Critical Path: #52 (map transitions) → #51 (items & catching) → #53 (money & mart) → #49 (trainer battles)
 

--- a/.claude/commands/milestone1.md
+++ b/.claude/commands/milestone1.md
@@ -41,4 +41,4 @@ Assign to: World Engineer
 Estimated: 1-2 hours
 ```
 
-Reference: https://github.com/githumps/conducted/milestone/1
+Reference: https://github.com/quadseven/conducted/milestone/1

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -16,7 +16,7 @@ Get a quick overview of project health and next steps.
 ## CONDUCTED Project Status
 **Date**: 2025-10-30
 **Version**: 1.0.8
-**Live URL**: https://githumps.github.io/conducted/
+**Live URL**: https://quadseven.github.io/conducted/
 
 ### Current Sprint: Milestone 1 - Core Gameplay Loop
 **Progress**: 4/18 issues complete (22%)
@@ -36,7 +36,7 @@ Get a quick overview of project health and next steps.
 ### Build Status
 - 🟢 **GitHub Pages**: Deployed successfully
 - 🟢 **Last Deploy**: 2025-10-30 14:10 UTC
-- 🟢 **Demo Works**: https://githumps.github.io/conducted/
+- 🟢 **Demo Works**: https://quadseven.github.io/conducted/
 
 ### Next Recommended Action
 👉 **Work on #52 (Fix map transitions)**

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   deploy:
-    uses: githumps/infra-public/.github/workflows/deploy.pages.yml@cd83e5727c0a7b904f780960664a51b3a3a0c685
+    uses: quadseven/infra-public/.github/workflows/deploy.pages.yml@cd83e5727c0a7b904f780960664a51b3a3a0c685
     with:
       artifact_path: "."

--- a/.github/workflows/guard.issue-close-completeness.yml
+++ b/.github/workflows/guard.issue-close-completeness.yml
@@ -1,6 +1,6 @@
 name: Guard · issue-close completeness
 
-# Thin caller of the shared reusable in githumps/infra-public — reopens an issue
+# Thin caller of the shared reusable in quadseven/infra-public — reopens an issue
 # closed as completed while it still has unchecked acceptance/test boxes. Logic +
 # escape hatches live in the reusable.
 
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   guard:
-    uses: githumps/infra-public/.github/workflows/check.issue-close-completeness.yml@cd83e5727c0a7b904f780960664a51b3a3a0c685
+    uses: quadseven/infra-public/.github/workflows/check.issue-close-completeness.yml@cd83e5727c0a7b904f780960664a51b3a3a0c685

--- a/DEVELOPMENT_ROADMAP.md
+++ b/DEVELOPMENT_ROADMAP.md
@@ -541,8 +541,8 @@ Goal: Prevent regressions in core loops
 - **Audio Specs:** `AUDIO_SPECIFICATIONS.md` (music/SFX requirements)
 
 ### External Resources
-- **GitHub Issues:** https://github.com/githumps/conducted/issues
-- **Milestones:** https://github.com/githumps/conducted/milestones
+- **GitHub Issues:** https://github.com/quadseven/conducted/issues
+- **Milestones:** https://github.com/quadseven/conducted/milestones
 - **Gen 1 Pokemon Mechanics:** https://bulbapedia.bulbagarden.net/wiki/Generation_I
 
 ---

--- a/DOCS/FIXES_SUMMARY_2025-11-03.md
+++ b/DOCS/FIXES_SUMMARY_2025-11-03.md
@@ -177,7 +177,7 @@ checkForEncounter(x, y) {
 **Branch:** `main`
 **Remote:** Pushed to GitHub
 **GitHub Pages:** Deploying (1-2 minutes)
-**Live URL:** https://githumps.github.io/conducted/
+**Live URL:** https://quadseven.github.io/conducted/
 
 ---
 

--- a/DOCS/SESSION_2025-11-04_GYM_PATH.md
+++ b/DOCS/SESSION_2025-11-04_GYM_PATH.md
@@ -150,7 +150,7 @@ const WORLD_MAPS = {
 **Branch:** `main`
 **Remote:** Pushed to origin/main
 **GitHub Pages:** Deploying (~1-2 minutes)
-**Live URL:** https://githumps.github.io/conducted/
+**Live URL:** https://quadseven.github.io/conducted/
 
 ---
 
@@ -313,7 +313,7 @@ Players can now:
 ## 🙏 Acknowledgments
 
 **Development:** Claude Code Agents (Parallel Execution)
-**Project:** CONDUCTED by githumps
+**Project:** CONDUCTED by quadseven
 **Inspiration:** Pokémon Red/Blue by Game Freak
 **Previous Session:** Bug fixes & Route 1 redesign (2025-11-03)
 

--- a/DOCS/SESSION_2025-11-04_MAP_RENDERING_FIX.md
+++ b/DOCS/SESSION_2025-11-04_MAP_RENDERING_FIX.md
@@ -239,7 +239,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - ✅ Live site verified working
 - ✅ Cache invalidated with query parameter
 
-**Live URL:** https://githumps.github.io/conducted/
+**Live URL:** https://quadseven.github.io/conducted/
 
 ---
 

--- a/DOCS/SESSION_COMPLETE_2025-11-03.md
+++ b/DOCS/SESSION_COMPLETE_2025-11-03.md
@@ -171,7 +171,7 @@
 - **Status:** ✅ Pushed to origin/main
 
 ### GitHub Pages:
-- **URL:** https://githumps.github.io/conducted/
+- **URL:** https://quadseven.github.io/conducted/
 - **Status:** ✅ Deployed
 - **Build Time:** ~60 seconds
 - **Cache:** May need hard refresh (Ctrl+Shift+R)
@@ -336,7 +336,7 @@ Missing features are **additions**, not **fixes**. The foundation is solid.
 **Playtesting:** Claude (AI Playtester)
 **Bug Fixes:** Claude Code Agents
 **Documentation:** Claude Code
-**Project:** CONDUCTED by githumps
+**Project:** CONDUCTED by quadseven
 **Inspiration:** Pokémon Red/Blue by Game Freak
 
 **Tools:**

--- a/ROADMAP_SUMMARY.md
+++ b/ROADMAP_SUMMARY.md
@@ -251,9 +251,9 @@ These 12 issues fill critical gaps in the Pokemon Red/Blue feature set that were
 - **Audio Specs:** `AUDIO_SPECIFICATIONS.md`
 
 ### Links
-- **GitHub Issues:** https://github.com/githumps/conducted/issues
-- **Milestones:** https://github.com/githumps/conducted/milestones
-- **Project Board:** https://github.com/githumps/conducted/projects
+- **GitHub Issues:** https://github.com/quadseven/conducted/issues
+- **Milestones:** https://github.com/quadseven/conducted/milestones
+- **Project Board:** https://github.com/quadseven/conducted/projects
 
 ---
 

--- a/tests/DEFEAT_HANDLING_TEST_PLAN.md
+++ b/tests/DEFEAT_HANDLING_TEST_PLAN.md
@@ -35,7 +35,7 @@ Create a save state with:
 
 ### Phase 1: Navigate to Battle Start
 ```
-1. Open browser and navigate to https://githumps.github.io/conducted/
+1. Open browser and navigate to https://quadseven.github.io/conducted/
 2. Wait for game to load (check for canvas element and "Load" button)
 3. Click "Load" button to load prepared save file
 4. Verify player position (should NOT be in Piston Town)
@@ -143,7 +143,7 @@ Create a save state with:
 ### Setup Phase
 ```javascript
 // Navigate to game
-mcp__playwright__browser_navigate({ url: "https://githumps.github.io/conducted/" })
+mcp__playwright__browser_navigate({ url: "https://quadseven.github.io/conducted/" })
 
 // Wait for load
 mcp__playwright__browser_wait_for({ time: 3 })

--- a/tests/DEFEAT_TEST_SUMMARY.md
+++ b/tests/DEFEAT_TEST_SUMMARY.md
@@ -15,7 +15,7 @@ After the defeat fix is implemented, verify that losing a battle correctly:
 ## Minimal Test Steps (Fast Version)
 
 ### Setup
-1. Load game at https://githumps.github.io/conducted/
+1. Load game at https://quadseven.github.io/conducted/
 2. Press **F1** to open debug menu
 3. Select **Wild Battle** to start a battle
 


### PR DESCRIPTION
## Summary

GitHub account `githumps` was renamed to `quadseven` (same numeric id `59060157`); this sweeps every remaining `githumps` reference in this repo. Functional fix: GitHub Pages URLs (`githumps.github.io/conducted/` -> `quadseven.github.io/conducted/`) - verified the old host now hard-404s while the new one returns 200, so these were dead links in docs/tests, not just cosmetic. Cosmetic (kept working today, updated for hygiene/squat-risk anyway): `github.com/githumps/conducted/...` doc links (issues, milestones, project board) which GitHub currently 301-redirects, the `uses: githumps/infra-public/...@<sha>` reusable-workflow refs in `deploy.yml` and `guard.issue-close-completeness.yml`, a workflow comment, and two "Project: CONDUCTED by githumps" bylines. No `ghcr.io`, `api.github.com`, or OIDC `repo:` references exist anywhere in this repo, so there was nothing to fix on those fronts.

Size: XS

## Test plan

- `grep -rn "githumps" .` (excluding `.git/`) returns zero matches after the change.
- Verified via `curl` that `https://quadseven.github.io/conducted/` returns 200 and the old `https://githumps.github.io/conducted/` returns 404.
- Verified `quadseven/infra-public` exists and the pinned SHA (`cd83e5727c0a7b904f780960664a51b3a3a0c685`) contains both reusable workflow files referenced (`deploy.pages.yml`, `check.issue-close-completeness.yml`).
- Validated both edited workflow YAML files parse (`ruby -ryaml`).

## Out of scope

- No functional/gameplay code changed - docs, workflow `uses:` refs, and dead-link URLs only. No package.json/test runner exists in this repo to run.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_016D3fnZfPL7A2esyoN1cuRE
